### PR TITLE
Fixed auto-clean and ban

### DIFF
--- a/src/commands/ban.js
+++ b/src/commands/ban.js
@@ -73,7 +73,7 @@ module.exports.run = async function(yuno, author, args, msg) {
                     .setCMDRequester(msg.member));
             */
             
-             if (yuno.commandMan._isUserMaster(msg.author.id))
+             if (yuno.commandMan._isUserMaster(target))
                  return msg.channel.send(new EmbedCmdResponse()
                      .setColor(FAIL_COLOR)
                      .setTitle(":negative_squared_cross_mark: Ban failed.")

--- a/src/modules/auto-cleaner.js
+++ b/src/modules/auto-cleaner.js
@@ -39,7 +39,7 @@ let setupCleaners = async function(Yuno) {
                 if (actualClean === null)
                     return;
 
-                let ch = g.channels.cache.find(name => el.channelName === 'channelName');
+                let ch = g.channels.cache.find((ch) => ch.name.toLowerCase() === el.channelName);
 
                 if (!(ch instanceof Channel)) {
                     Yuno.dbCommands.delClean(Yuno.database, el.guildId, el.channelName)


### PR DESCRIPTION
Line 76 `src/commands/ban.js`
old -> `yuno.commandMan._isUserMaster(msg.author.id)`
new -> `yuno.commandMan._isUserMaster(target)`

Line 42 `src/modules/auto-cleaner.js`
old -> `let ch = g.channels.cache.find(name => el.channelName === 'channelName');`
new -> `let ch = g.channels.cache.find((ch) => ch.name.toLowerCase() === el.channelName);`