### PR TITLE
Modernize codebase for newer Node.js versions

### DIFF
--- a/src/ModuleExporter.js
+++ b/src/ModuleExporter.js
@@ -17,13 +17,12 @@
 */
 
 const EventEmitter = require("events"),
-    Util = require("util")
     fs = require("fs"),
     prompt = (require("./lib/prompt")).init(),
-    Path = require("path"),
-    Yuno = null;
+    Path = require("path");
 
-let instance = null;
+let instance = null,
+    Yuno = null;
 
 /*
  * @event hot-reload(?file) When a file will be hot-reloaded.
@@ -35,272 +34,272 @@ let instance = null;
 
 /**
  * The module exporter
- * @constructor
  * @description Exports Modules, and makes them hot-reloadable.
  * @deprecated Use ModuleExporter.init() to create an instance of ModuleExporter. Do not use new ModuleExporter();
  * @extends EventEmitter
  * @prop {Object} modules An object with key as path, and value as the module
  * @prop {array} hotreloadReferences All references that will be updated on a hot-reload
  */
-let ModuleExporter = function() {
-    this.modules = {};
+class ModuleExporter extends EventEmitter {
+    constructor() {
+        super();
+        this.modules = {};
 
-    this.hotreloadReferences = {};
+        this.hotreloadReferences = {};
 
-    this._inithrReference();
-}
-
-Util.inherits(ModuleExporter, EventEmitter)
-
-/**
- * Inits the singleton
- * @return {ModuleExporter} The instance.
- */
-ModuleExporter.init = function() {
-    if (instance === null)
-        instance = new ModuleExporter();
-    return instance;
-}
-
-/**
- * Exports the main Yuno reference to ModuleExporter.
- * Used for debug purposes, with the auto -hot-reload
- * @param {Yuno} yuno 
- */
-ModuleExporter.prototype.heresYuno = function(yuno) {
-    Yuno = yuno;
-}
-
-/**
- * Pushes a new hot-reload reference.
- * @param {Object} instance An instance where a prop will be updated.
- * @param {String} prop The property of the instance, where the module instance is located.
- * @param {String} file The location of the module
- * @return {EventEmitter} "hot-reloaded"(module): Triggered when the file has been hot-reloaded. Consider constructing your classes again.
- */
-ModuleExporter.prototype.hrReference = function(instance, prop, file) {
-    let path = require.resolve(file),
-        ee = new EventEmitter();
-
-    this.hotreloadReferences[path] = {
-        "eventEmitter": ee,
-        "instance": instance,
-        "prop": prop
-    };
-
-    return ee;
-}
-
-/**
- * Trigger all hot-reload references.
- * @private
- * @param {String} path The path to the reference (the file)
- */
-ModuleExporter.prototype._triggerhrReference = function(path) {
-    if (typeof path !== "string")
-        return;
-
-    let rf = this.hotreloadReferences[path];
-
-    if (!rf)
-        return;
-
-    let backup = {};
-
-    rf.eventEmitter.emit("reloading", backup);
-
-    let mod = this._loadModule(path);
-
-    if (rf.instance && typeof rf.prop === "string")
-        rf.instance[rf.prop] = mod;
-
-    rf.eventEmitter.emit("done", mod, backup)
-}
-
-/**
- * Makes link between hot-reload events.
- * @private
- */
-ModuleExporter.prototype._inithrReference = function() {
-    this.on("hot-reload-end", (function(path) {
-        this._triggerhrReference(path);
-    }).bind(this));
-}
-
-/**
- * Requires a new module and returns it
- * @param {String} file
- * @return {Object} The module.
- */
-ModuleExporter.prototype.require = function(file) {
-    let path = require.resolve(file);
-
-    return this.modules[path] = this._loadModule(path);
-}
-
-/**
- * Requires and do a hot-reload reference
- * @param {String} file
- * @param {Object} instance
- * @param {String} prop
- * @alias .require -> .hrReference
- * @returns {EventEmitter} with property .module, containing the module.
- */
-ModuleExporter.prototype.requireAndRef = function(file, instance, prop) {
-    let path = require.resolve(file),
-        ee = this.hrReference(instance, prop, file);
-
-    ee.module = this.modules[path] = this._loadModule(path);
-
-    return ee;
-}
-
-/**
- * Exports a singleton, init it, make it hot-reloadable and returns it.
- * A little way to make singleton declaring quicker & easier & more human-readable.
- * @param {Object} instance
- * @param {String} file The file without extension
- * @param {String?} [prop] The property. Defaults to filename
- * @param {String?} [subdir] The subdir to the file w/out end trainling slash. Defaults to "./src/lib".
- * @param {any?} [arg] Argument to .init of the singleton
- * @return {Object} Module.
- */
-ModuleExporter.prototype.singletonPreset = function(instance, file, prop, subdir, arg) {
-    if (typeof subdir !== "string")
-        subdir = "./lib";
-
-    if (typeof prop !== "string")
-        prop = file;
-
-
-    return this.requireAndRef(subdir + "/" + file, instance, prop).on("reloading", (function(backup) {
-        if (instance[prop] && instance[prop].backup)
-            backup = instance[prop].backup();
-        else
-            console.log("Error with " + prop + " no backup()")
-    }).bind(instance)).on("done", (function(MOD, backupdata) {
-        delete instance[prop];
-        instance[prop] = MOD.init(backupdata);
-    }).bind(instance)).module.init(arg);
-}
-
-/**
- * Exports a Class, construct it, make it hot-reloadable and returns it.
- * Used to make class declaring & constructing quicker, easier & more human-readable
- * @param {Object} instance
- * @param {String} file The file without extension
- * @param {String?} [prop] The property. Defaults to filename
- * @param {String?} [subdir] The subdir to the file w/out end trailing slash
- * @param {any} arg Argument used when the instance will be instancied: new Class(arg);
- */
-ModuleExporter.prototype.instancePreset = function(instance, file, prop, subdir, arg) {
-    if (typeof subdir !== "string")
-        subdir = "./lib";
-
-    if (typeof prop !== "string")
-        prop = file;
-
-    return new (this.requireAndRef(subdir + "/" + file, this, prop).on("reloading", (function(backup) {
-        if (instance[prop] && instance[prop].backup)
-            backup = instance[prop].backup();
-        else
-            console.log("Error with " + prop + " no backup()")
-    }).bind(instance)).on("done", (function(MOD, backupdata) {
-        delete instance[prop];
-        instance[prop] = new MOD(backupdata);
-    }).bind(instance)).module)(arg);
-}
-
-/**
- * Hot Reload a modules.
- * @param {?string} file The file as module that has to be reloaded. If undefined/null, it'll reload all modules.
- * @description Hot reload a specific module.
- */
-ModuleExporter.prototype.hotreload = function(file) {
-    let path;
-
-    if (typeof file === "undefined" || file === "null")
-        return this._hotreloadAllFiles();
-    else {
-        this.emit("hot-reload", file);
-        path = require.resolve(file);
-        this.modules[path] = this._loadModule(path);
+        this._inithrReference();
     }
 
-    this.emit("hot-reload-end", path);
-}
-
-/**
- * Hot reload all files. (files = required modules)
- * @private
- */
-ModuleExporter.prototype._hotreloadAllFiles = function() {
-    this.emit("hot-reload-full");
-    Object.keys(this.modules).forEach(((el, ind, arr) => {
-        this.hotreload(el);
-    }).bind(this));
-    this.emit("hot-reload-full-end");
-}
-
-/**
- * Loads a module
- * @param {string} path The path to the module
- * @private
- * @description Deletes cache, and require (again) the module
- */
-ModuleExporter.prototype._loadModule = function(path) {
-    if (require.cache[path])
-        delete require.cache[path];
-
-    try {
-        return require(path);
-    } catch(e) {
-        prompt.error("Fatal error: Module " + path + " has a syntax error :\n" + e.message);
-        process.exit(0);
+    /**
+     * Inits the singleton
+     * @return {ModuleExporter} The instance.
+     */
+    static init() {
+        if (instance === null)
+            instance = new ModuleExporter();
+        return instance;
     }
-}
 
-/**
- * Returns if the file is an exported module
- * @param {String} path
- * @private
- * @return {boolean} If the file given (as path) is a module (that has been exported).
- */
-ModuleExporter.prototype._isAnExportedModule = function(path) {
-    path = require.resolve(path);
-    return !(typeof this.modules[path] === "undefined");
-}
+    /**
+     * Exports the main Yuno reference to ModuleExporter.
+     * Used for debug purposes, with the auto -hot-reload
+     * @param {Yuno} yuno
+     */
+    heresYuno(yuno) {
+        Yuno = yuno;
+    }
 
-/**
- * Watches a directory. In case of any changes, the modules will be reloaded.
- * @param {String?} [towatch] The file/directory to watch. Defaults to dir "src"
- * @return {String} The directory/file watched.
- */
-ModuleExporter.prototype.watch = function(towatch) {
-    if (typeof towatch === "undefined" || towatch === null)
-        towatch = "./src/";
+    /**
+     * Pushes a new hot-reload reference.
+     * @param {Object} instance An instance where a prop will be updated.
+     * @param {String} prop The property of the instance, where the module instance is located.
+     * @param {String} file The location of the module
+     * @return {EventEmitter} "hot-reloaded"(module): Triggered when the file has been hot-reloaded. Consider constructing your classes again.
+     */
+    hrReference(instance, prop, file) {
+        let path = require.resolve(file),
+            ee = new EventEmitter();
+
+        this.hotreloadReferences[path] = {
+            "eventEmitter": ee,
+            "instance": instance,
+            "prop": prop
+        };
+
+        return ee;
+    }
+
+    /**
+     * Trigger all hot-reload references.
+     * @private
+     * @param {String} path The path to the reference (the file)
+     */
+    _triggerhrReference(path) {
+        if (typeof path !== "string")
+            return;
+
+        let rf = this.hotreloadReferences[path];
+
+        if (!rf)
+            return;
+
+        let backup = {};
+
+        rf.eventEmitter.emit("reloading", backup);
+
+        let mod = this._loadModule(path);
+
+        if (rf.instance && typeof rf.prop === "string")
+            rf.instance[rf.prop] = mod;
+
+        rf.eventEmitter.emit("done", mod, backup)
+    }
+
+    /**
+     * Makes link between hot-reload events.
+     * @private
+     */
+    _inithrReference() {
+        this.on("hot-reload-end", (path) => {
+            this._triggerhrReference(path);
+        });
+    }
+
+    /**
+     * Requires a new module and returns it
+     * @param {String} file
+     * @return {Object} The module.
+     */
+    require(file) {
+        let path = require.resolve(file);
+
+        return this.modules[path] = this._loadModule(path);
+    }
+
+    /**
+     * Requires and do a hot-reload reference
+     * @param {String} file
+     * @param {Object} instance
+     * @param {String} prop
+     * @alias .require -> .hrReference
+     * @returns {EventEmitter} with property .module, containing the module.
+     */
+    requireAndRef(file, instance, prop) {
+        let path = require.resolve(file),
+            ee = this.hrReference(instance, prop, file);
+
+        ee.module = this.modules[path] = this._loadModule(path);
+
+        return ee;
+    }
+
+    /**
+     * Exports a singleton, init it, make it hot-reloadable and returns it.
+     * A little way to make singleton declaring quicker & easier & more human-readable.
+     * @param {Object} instance
+     * @param {String} file The file without extension
+     * @param {String?} [prop] The property. Defaults to filename
+     * @param {String?} [subdir] The subdir to the file w/out end trainling slash. Defaults to "./src/lib".
+     * @param {any?} [arg] Argument to .init of the singleton
+     * @return {Object} Module.
+     */
+    singletonPreset(instance, file, prop, subdir, arg) {
+        if (typeof subdir !== "string")
+            subdir = "./lib";
+
+        if (typeof prop !== "string")
+            prop = file;
 
 
-    fs.watch(towatch, {
-        "persistent": false, // Indicates whether the process should continue to run as long as files are being watched.
-        "recursive": true,
-    }, (async function(eType, file) {
-        file = Path.join(__dirname, file);
-        if (this._isAnExportedModule(file)) {
-            this.emit("file-changed", file);
-            this.hotreload(file);
-            prompt.debug("File " + file + " hot-reloaded.");
-        } else {
-            prompt.debug("Reloading all the bot (we're in a debug env, np huh ?)")
-            prompt.warning("In case of a production environment, it's better to disable auto hot-reload for better stability.");
-            if (Yuno)
-                await Yuno.hotreload();
+        return this.requireAndRef(subdir + "/" + file, instance, prop).on("reloading", function(backup) {
+            if (instance[prop] && instance[prop].backup)
+                backup = instance[prop].backup();
             else
-                prompt.warning("Yuno's hot reload cancelled. Yuno's reference has been not defined.")
-        }
-    }).bind(this));
+                console.log("Error with " + prop + " no backup()")
+        }).on("done", function(MOD, backupdata) {
+            delete instance[prop];
+            instance[prop] = MOD.init(backupdata);
+        }).module.init(arg);
+    }
 
-    return towatch;
+    /**
+     * Exports a Class, construct it, make it hot-reloadable and returns it.
+     * Used to make class declaring & constructing quicker, easier & more human-readable
+     * @param {Object} instance
+     * @param {String} file The file without extension
+     * @param {String?} [prop] The property. Defaults to filename
+     * @param {String?} [subdir] The subdir to the file w/out end trailing slash
+     * @param {any} arg Argument used when the instance will be instancied: new Class(arg);
+     */
+    instancePreset(instance, file, prop, subdir, arg) {
+        if (typeof subdir !== "string")
+            subdir = "./lib";
+
+        if (typeof prop !== "string")
+            prop = file;
+
+        return new (this.requireAndRef(subdir + "/" + file, this, prop).on("reloading", function(backup) {
+            if (instance[prop] && instance[prop].backup)
+                backup = instance[prop].backup();
+            else
+                console.log("Error with " + prop + " no backup()")
+        }).on("done", function(MOD, backupdata) {
+            delete instance[prop];
+            instance[prop] = new MOD(backupdata);
+        }).module)(arg);
+    }
+
+    /**
+     * Hot Reload a modules.
+     * @param {?string} file The file as module that has to be reloaded. If undefined/null, it'll reload all modules.
+     * @description Hot reload a specific module.
+     */
+    hotreload(file) {
+        let path;
+
+        if (typeof file === "undefined" || file === "null")
+            return this._hotreloadAllFiles();
+        else {
+            this.emit("hot-reload", file);
+            path = require.resolve(file);
+            this.modules[path] = this._loadModule(path);
+        }
+
+        this.emit("hot-reload-end", path);
+    }
+
+    /**
+     * Hot reload all files. (files = required modules)
+     * @private
+     */
+    _hotreloadAllFiles() {
+        this.emit("hot-reload-full");
+        Object.keys(this.modules).forEach((el, ind, arr) => {
+            this.hotreload(el);
+        });
+        this.emit("hot-reload-full-end");
+    }
+
+    /**
+     * Loads a module
+     * @param {string} path The path to the module
+     * @private
+     * @description Deletes cache, and require (again) the module
+     */
+    _loadModule(path) {
+        if (require.cache[path])
+            delete require.cache[path];
+
+        try {
+            return require(path);
+        } catch(e) {
+            prompt.error("Fatal error: Module " + path + " has a syntax error :\n" + e.message);
+            process.exit(0);
+        }
+    }
+
+    /**
+     * Returns if the file is an exported module
+     * @param {String} path
+     * @private
+     * @return {boolean} If the file given (as path) is a module (that has been exported).
+     */
+    _isAnExportedModule(path) {
+        path = require.resolve(path);
+        return !(typeof this.modules[path] === "undefined");
+    }
+
+    /**
+     * Watches a directory. In case of any changes, the modules will be reloaded.
+     * @param {String?} [towatch] The file/directory to watch. Defaults to dir "src"
+     * @return {String} The directory/file watched.
+     */
+    watch(towatch) {
+        if (typeof towatch === "undefined" || towatch === null)
+            towatch = "./src/";
+
+
+        fs.watch(towatch, {
+            "persistent": false, // Indicates whether the process should continue to run as long as files are being watched.
+            "recursive": true,
+        }, async (eType, file) => {
+            file = Path.join(__dirname, file);
+            if (this._isAnExportedModule(file)) {
+                this.emit("file-changed", file);
+                this.hotreload(file);
+                prompt.debug("File " + file + " hot-reloaded.");
+            } else {
+                prompt.debug("Reloading all the bot (we're in a debug env, np huh ?)")
+                prompt.warning("In case of a production environment, it's better to disable auto hot-reload for better stability.");
+                if (Yuno)
+                    await Yuno.hotreload();
+                else
+                    prompt.warning("Yuno's hot reload cancelled. Yuno's reference has been not defined.")
+            }
+        });
+
+        return towatch;
+    }
 }
 
 module.exports = ModuleExporter;

--- a/src/Yuno.js
+++ b/src/Yuno.js
@@ -25,10 +25,7 @@ const DEFAULT_CONFIG_FILE = "config.json",
 
     PACKAGE = require("../package.json");
 
-const Util = require("util"),
-    fs = require("fs"),
-    fsPromises = require("fs").promises,
-    path = require("path"),
+const fsPromises = require("fs").promises,
     EventEmitter = require("events"),
     {Client, GatewayIntentBits} = require("discord.js");
 
@@ -43,7 +40,6 @@ let ONETIME_EVENT = false
 
 /**
  * Main Yuno Gasai 2 Class
- * @constructor
  * @extends EventEmitter
  * @prop {Prompt} prompt
  * @prop {InteractiveTerminal} interactiveTerm
@@ -58,211 +54,212 @@ let ONETIME_EVENT = false
  * @prop {Object} hotreloadDisabledReasons An object containing the reasons of disabled hot-reload. As key an id, and as value the reason.
  * @description The main bot's class.
  */
-let Yuno = function() {
-    this.prompt = ModuleExporter.singletonPreset(this, "prompt")
+class Yuno extends EventEmitter {
+    constructor() {
+        super();
 
-    // Not hot-reloading this one: it's the core of interactivity => essential.
-    this.interactiveTerm = (require("./lib/interactiveTerm")).init((function(cmd) {
-        return new Promise((async function(res, rej) {
-            try { await this.commandMan.execute(this, null, cmd) } catch(e) {
-                this.prompt.error("Error happened while executing command", e);
-            }
-            res();
-        }).bind(this))
-    }).bind(this));
+        this.prompt = ModuleExporter.singletonPreset(this, "prompt")
 
-    this.database = new Database();
+        // Not hot-reloading this one: it's the core of interactivity => essential.
+        this.interactiveTerm = (require("./lib/interactiveTerm")).init((cmd) => {
+            return new Promise(async (res, rej) => {
+                try { await this.commandMan.execute(this, null, cmd) } catch(e) {
+                    this.prompt.error("Error happened while executing command", e);
+                }
+                res();
+            });
+        });
 
-    this.dbCommands = DatabaseCommands = ModuleExporter.requireAndRef("./DatabaseCommands").on("done", (function(module) {
-        this.dbCommands = DatabaseCommands = module;
-    }).bind(this)).module;
+        this.database = new Database();
 
-    this.commandMan = ModuleExporter.instancePreset(this, "commandManager", "commandMan", null);
+        this.dbCommands = DatabaseCommands = ModuleExporter.requireAndRef("./DatabaseCommands").on("done", (module) => {
+            this.dbCommands = DatabaseCommands = module;
+        }).module;
 
-    this.discordClient = new Client({
-        intents: [
-            GatewayIntentBits.Guilds,
-            GatewayIntentBits.GuildMembers,
-            GatewayIntentBits.GuildMessages,
-            GatewayIntentBits.MessageContent,
-            GatewayIntentBits.DirectMessages,
-            GatewayIntentBits.GuildBans
-        ]
-    });
-    this.dC = this.discordClient;
+        this.commandMan = ModuleExporter.instancePreset(this, "commandManager", "commandMan", null);
 
-    this.configMan = ModuleExporter.singletonPreset(this, "configManager", "configMan");
+        this.discordClient = new Client({
+            intents: [
+                GatewayIntentBits.Guilds,
+                GatewayIntentBits.GuildMembers,
+                GatewayIntentBits.GuildMessages,
+                GatewayIntentBits.MessageContent,
+                GatewayIntentBits.DirectMessages,
+                GatewayIntentBits.GuildBans
+            ]
+        });
+        this.dC = this.discordClient;
 
-    this.intervalMan = ModuleExporter.singletonPreset(this, "intervalManager", "intervalMan");
+        this.configMan = ModuleExporter.singletonPreset(this, "configManager", "configMan");
 
-    this.config = null;
+        this.intervalMan = ModuleExporter.singletonPreset(this, "intervalManager", "intervalMan");
 
-    this.modules = []
+        this.config = null;
 
-    this.interactivity = true;
+        this.modules = []
 
-    this.version = PACKAGE.version;
-    this.intVersion = parseInt(PACKAGE.version.replace(new RegExp("[.]", "gi"), ""));
+        this.interactivity = true;
 
-    this.prompt.info("Yuno " + this.version + " initialised.")
+        this.version = PACKAGE.version;
+        this.intVersion = parseInt(PACKAGE.version.replace(new RegExp("[.]", "gi"), ""));
 
-    this.hotreloadDisabledReasons = {};
+        this.prompt.info("Yuno " + this.version + " initialised.")
 
-    this.UTIL = ModuleExporter.requireAndRef("./Util").on("done", (function(module) {
-        this.UTIL = module;
-    }).bind(this)).module;
+        this.hotreloadDisabledReasons = {};
 
-    ModuleExporter.heresYuno(this);
-}
+        this.UTIL = ModuleExporter.requireAndRef("./Util").on("done", (module) => {
+            this.UTIL = module;
+        }).module;
 
-Util.inherits(Yuno, EventEmitter);
-
-/**
- * Hot reloads all classes/required modules except Yuno & ModuleExporter.
- */
-Yuno.prototype.hotreload = async function() {
-    if (Object.keys(this.hotreloadDisabledReasons).length > 0) {
-        let r = Object.values(this.hotreloadDisabledReasons)[0];
-        this.prompt.error("Hot-reload aborted because hr is disabled, reason: " + r);
-        return r;
+        ModuleExporter.heresYuno(this);
     }
 
-    this.prompt.info("Hot-reloading. Bot may be unresponsive while hot-reloading.");
-
-    this.removeAllListeners();
-    this.dC.removeAllListeners();
-    await this._triggerShutdownEvents();
-    this.modules = [];
-
-    ModuleExporter.once("hot-reload-full-end", (async function () {
-        await this._init();
-        await this.readConfig(DEFAULT_CONFIG_FILE);
-        this._loadModulesHR();
-        await this._triggerConfigEvents();
-        this.prompt.success("Bot has successfully hot-reloaded!");
-    }).bind(this));
-
-    ModuleExporter.hotreload();
-
-    return;
-}
-
-/**
- * Inits Yuno.
- * @private
- * @return {Promise}
- */
-Yuno.prototype._init = function() {
-    return new Promise((async function(resolve, reject) {
-        this.commandMan.on("loaded", (function() {
-            if (this.interactivity)
-                this.interactiveTerm.listen();
-        }).bind(this));
-
-        await this.commandMan.init();
-
-        if (!ONETIME_EVENT) {
-            ONETIME_EVENT = true;
-
-            this.interactiveTerm.on("quit", (function() {
-                this.shutdown(1);
-            }).bind(this));
-
-            process.on("uncaughtException", (function(e) {
-                this._uncaughtException(e);
-            }).bind(this))
-            process.on("unhandledRejection", (function(e) {
-                this._unhandledRejection(e);
-            }).bind(this));
-            this.dC.on("error", (function(e) {
-                this.prompt.error("Discord.JS's client threw an error", e);
-            }).bind(this));
+    /**
+     * Hot reloads all classes/required modules except Yuno & ModuleExporter.
+     */
+    async hotreload() {
+        if (Object.keys(this.hotreloadDisabledReasons).length > 0) {
+            let r = Object.values(this.hotreloadDisabledReasons)[0];
+            this.prompt.error("Hot-reload aborted because hr is disabled, reason: " + r);
+            return r;
         }
-        resolve();
-    }).bind(this));
-}
 
-/**
- * Shows a nice CLI help.
- */
-Yuno.prototype.showCLIHelp = function() {
-    return this.prompt.showHelp([
-        {
-            "argument": "--help",
-            "aliases": ["-h"],
-            "description": "Shows this."
-        }, {
-            "argument": "--token=[token]",
-            "description": "Starts the bot with a new token. The bot next save the token."
-        }, {
-            "argument": "--hot-reload",
-            "aliases": ["-hr"],
-            "description": "Hot-reloads on file change."
-        }, {
-            "argument": "--no-interactions",
-            "aliases": ["-noit"],
-            "description": "Removes the interactions with the terminal."
-        }, {
-            "argument": "--debug-script",
-            "description": "Evalutes debug-script.js when ready."
-        }, {
-            "argument": "--upgrade-database=v1yunodb.db;destination.db",
-            "description": "Updates the Yuno's 1st version database to the Yuno's 2nd database"
-        }, {
-            "argument": "--quick-crash",
-            "aliases": ["-qc"],
-            "description": "Stops the process on any uncaught exception or unhandled rejection."
-        }, {
-            "argument": "--no-colors",
-            "aliases": ["-nc"],
-            "description": "Logs without any color."
-        }
-    ])
-}
+        this.prompt.info("Hot-reloading. Bot may be unresponsive while hot-reloading.");
 
-/**
- * Evals a code under with the Yuno's context.
- * @param {String} code
- * @warning Don't provide any shit to this method.
- * @async
- * @returns {any} The result of the "eval"
- * @private
- */
-Yuno.prototype._eval = function(code) {
-    return eval(code)
-}
+        this.removeAllListeners();
+        this.dC.removeAllListeners();
+        await this._triggerShutdownEvents();
+        this.modules = [];
 
-/**
- * Upgrades the Yuno's first version database to this version
- * @private
- * @param {String} file
- * @param {String} destination The filename of the destination file.
- * @return {Promise}
- */
-Yuno.prototype._upgradeDb = function(file, destination) {
-    this.prompt.warn("The terminal will have no interactivity while updating the database...");
-    return DatabaseCommands.upgrade(this, this.prompt, file, destination);
-}
+        ModuleExporter.once("hot-reload-full-end", async () => {
+            await this._init();
+            await this.readConfig(DEFAULT_CONFIG_FILE);
+            this._loadModulesHR();
+            await this._triggerConfigEvents();
+            this.prompt.success("Bot has successfully hot-reloaded!");
+        });
 
-/**
- * Parse arguments & launches the bot.
- * @param {array} pargv process.argv
- * @description Used to parse the process.argv arguments
- * @async
- */
-Yuno.prototype.parseArguments = async function(pargv) {
-    // duplicating
-    pargv = Array.from(pargv).slice(2).concat([""]);
+        ModuleExporter.hotreload();
 
-    if (pargv.includes("--help") || pargv.includes("-h"))
-        return this.showCLIHelp();
+        return;
+    }
 
-    // Display ASCII art banner - using RGB escape for #c88c8d (dusty rose pink)
-    const YUNO_PINK = "\x1b[38;2;200;140;141m";
-    const YUNO_PINK_BOLD = "\x1b[1;38;2;200;140;141m";
-    const RESET = "\x1b[0m";
+    /**
+     * Inits Yuno.
+     * @private
+     * @return {Promise}
+     */
+    _init() {
+        return new Promise(async (resolve, reject) => {
+            this.commandMan.on("loaded", () => {
+                if (this.interactivity)
+                    this.interactiveTerm.listen();
+            });
 
-    console.log(`
+            await this.commandMan.init();
+
+            if (!ONETIME_EVENT) {
+                ONETIME_EVENT = true;
+
+                this.interactiveTerm.on("quit", () => {
+                    this.shutdown(1);
+                });
+
+                process.on("uncaughtException", (e) => {
+                    this._uncaughtException(e);
+                })
+                process.on("unhandledRejection", (e) => {
+                    this._unhandledRejection(e);
+                });
+                this.dC.on("error", (e) => {
+                    this.prompt.error("Discord.JS's client threw an error", e);
+                });
+            }
+            resolve();
+        });
+    }
+
+    /**
+     * Shows a nice CLI help.
+     */
+    showCLIHelp() {
+        return this.prompt.showHelp([
+            {
+                "argument": "--help",
+                "aliases": ["-h"],
+                "description": "Shows this."
+            }, {
+                "argument": "--token=[token]",
+                "description": "Starts the bot with a new token. The bot next save the token."
+            }, {
+                "argument": "--hot-reload",
+                "aliases": ["-hr"],
+                "description": "Hot-reloads on file change."
+            }, {
+                "argument": "--no-interactions",
+                "aliases": ["-noit"],
+                "description": "Removes the interactions with the terminal."
+            }, {
+                "argument": "--debug-script",
+                "description": "Evalutes debug-script.js when ready."
+            }, {
+                "argument": "--upgrade-database=v1yunodb.db;destination.db",
+                "description": "Updates the Yuno's 1st version database to the Yuno's 2nd database"
+            }, {
+                "argument": "--quick-crash",
+                "aliases": ["-qc"],
+                "description": "Stops the process on any uncaught exception or unhandled rejection."
+            }, {
+                "argument": "--no-colors",
+                "aliases": ["-nc"],
+                "description": "Logs without any color."
+            }
+        ])
+    }
+
+    /**
+     * Evals a code under with the Yuno's context.
+     * @param {String} code
+     * @warning Don't provide any shit to this method.
+     * @async
+     * @returns {any} The result of the "eval"
+     * @private
+     */
+    _eval(code) {
+        return eval(code)
+    }
+
+    /**
+     * Upgrades the Yuno's first version database to this version
+     * @private
+     * @param {String} file
+     * @param {String} destination The filename of the destination file.
+     * @return {Promise}
+     */
+    _upgradeDb(file, destination) {
+        this.prompt.warn("The terminal will have no interactivity while updating the database...");
+        return DatabaseCommands.upgrade(this, this.prompt, file, destination);
+    }
+
+    /**
+     * Parse arguments & launches the bot.
+     * @param {array} pargv process.argv
+     * @description Used to parse the process.argv arguments
+     * @async
+     */
+    async parseArguments(pargv) {
+        // duplicating
+        pargv = Array.from(pargv).slice(2).concat([""]);
+
+        if (pargv.includes("--help") || pargv.includes("-h"))
+            return this.showCLIHelp();
+
+        // Display ASCII art banner - using RGB escape for #c88c8d (dusty rose pink)
+        const YUNO_PINK = "\x1b[38;2;200;140;141m";
+        const YUNO_PINK_BOLD = "\x1b[1;38;2;200;140;141m";
+        const RESET = "\x1b[0m";
+
+        console.log(`
 ${YUNO_PINK}⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠂⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⣯⢻⡘⢷⠀⠀⠀⠀⠀⠀⣿⣦⠹⡄⠀⢿⠟⣿⡆⠀⠸⡄⠀⢸⡄⠀⠀⠀⠀⠀⠀⠀⠀⣧
 ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢠⡄⠀⢸⣤⣳⡘⣇⠀⠀⠀⠀⠀⢸⣟⣆⢻⣆⢸⡆⢹⣿⣄⠀⣷⠀⢰⡇⠀⠀⠀⠀⠀⠀⠀⠀⢸
 ⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢀⠸⡄⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⠀⢸⣇⠀⠈⣆⠹⣿⣸⡇⡄⠀⠀⠀⢸⢧⠀⠈⠻⣆⢿⠀⠉⢻⡆⢹⠀⢸⡇⠀⠀⠀⠀⠀⠀⠀⠀⢸
@@ -301,435 +298,436 @@ ${YUNO_PINK_BOLD}                    ♥ Yuno Gasai v${this.version} ♥${RESET}
 ${YUNO_PINK}           "I'll protect this server forever... just for you~"${RESET}
 `);
 
-    this.interactivity = !((pargv.includes("--no-interactions") || pargv.includes("-noit") || process.env.NO_INTERACTION))
+        this.interactivity = !((pargv.includes("--no-interactions") || pargv.includes("-noit") || process.env.NO_INTERACTION))
 
-    if (!this.interactivity)
-        this.prompt.warning("Interactive terminal is disabled.");
+        if (!this.interactivity)
+            this.prompt.warning("Interactive terminal is disabled.");
 
-    for(let i = 0; i < pargv.length; i++) {
-        let el = pargv[i];
+        for(let i = 0; i < pargv.length; i++) {
+            let el = pargv[i];
 
-        if (el.indexOf("--token") === 0) {
-            if (el.indexOf("--token=") === 0)
-                CUSTOM_TOKEN = el.split("=")[1];
-            else
-                this.prompt.warning("Not any new token defined. You have to define token like --token=yourtoken")
-        }
-
-        if (el.indexOf("--custom-config") === 0) {
-            if (el.indexOf("--custom-config=") === 0) {
-                CUSTOM_CONFIG_FILE = el.split("=")[1];
-            } else
-                this.prompt.warning("Not any custom config path defined. You have to define path like --custom-config=yourconfig.json");
-        }
-
-        if (el.indexOf("--upgrade-database") === 0) {
-            if (!this.interactivity)
-                return this.prompt.error("Cannot upgrade database without interactive terminal.");
-
-            if (el.indexOf("--upgrade-database=") === 0) {
-                let files = el.split("=")[1].split(";"),
-                    file = files[0],
-                    to = files[1]
-
-                if (!file || file === "")
-                    this.prompt.warn("No source file given to --upgrade-database. Example: --customconfig=yunov1.db;destination.db");
-                else if (!to || to === "")
-                    return this.prompt.warn("No destination file for --upgrade-database. Example: --customconfig=yunov1.db;destination.db");
-                else {
-                    process.on("uncaughtException", (function(e) {
-                        this._uncaughtException(e);
-                    }).bind(this))
-                    process.on("unhandledRejection", (function(e) {
-                        this._unhandledRejection(e);
-                    }).bind(this));
-
-                    this.interactiveTerm.setHandler((async function(enter) {
-                        if (enter === "yes") {
-                            this.interactiveTerm.stop();
-                            this.prompt.info("Starting the upgrade of the database...");
-                            await this._upgradeDb(file, to);
-                        } else if (enter === "no") {
-                            this.prompt.info("You cancelled the upgrade of the database. Stopping...");
-                            this.shutdown(3);
-                        } else {
-                            this.prompt.warn("Please enter either \"yes\" or \"no\".");
-                        }
-                    }).bind(this))
-
-                    this.interactiveTerm.on("quit", (function() {
-                        this.shutdown(3)
-                    }).bind(this))
-
-                    this.interactiveTerm.listen();
-
-                    this.prompt.info("If your destination file " + to + " exists, it'll be erased.");
-                    this.prompt.info("The database " + file + " will not be affected by the upgrade.");
-                    this.prompt.info("Please confirm the upgrading of the database by entering \"yes\" or \"no\" in lowercase then press Enter.");
-                }
-            } else {
-                this.prompt.warn("No value given to --upgrade-database.");
+            if (el.indexOf("--token") === 0) {
+                if (el.indexOf("--token=") === 0)
+                    CUSTOM_TOKEN = el.split("=")[1];
+                else
+                    this.prompt.warning("Not any new token defined. You have to define token like --token=yourtoken")
             }
+
+            if (el.indexOf("--custom-config") === 0) {
+                if (el.indexOf("--custom-config=") === 0) {
+                    CUSTOM_CONFIG_FILE = el.split("=")[1];
+                } else
+                    this.prompt.warning("Not any custom config path defined. You have to define path like --custom-config=yourconfig.json");
+            }
+
+            if (el.indexOf("--upgrade-database") === 0) {
+                if (!this.interactivity)
+                    return this.prompt.error("Cannot upgrade database without interactive terminal.");
+
+                if (el.indexOf("--upgrade-database=") === 0) {
+                    let files = el.split("=")[1].split(";"),
+                        file = files[0],
+                        to = files[1]
+
+                    if (!file || file === "")
+                        this.prompt.warn("No source file given to --upgrade-database. Example: --customconfig=yunov1.db;destination.db");
+                    else if (!to || to === "")
+                        return this.prompt.warn("No destination file for --upgrade-database. Example: --customconfig=yunov1.db;destination.db");
+                    else {
+                        process.on("uncaughtException", (e) => {
+                            this._uncaughtException(e);
+                        })
+                        process.on("unhandledRejection", (e) => {
+                            this._unhandledRejection(e);
+                        });
+
+                        this.interactiveTerm.setHandler(async (enter) => {
+                            if (enter === "yes") {
+                                this.interactiveTerm.stop();
+                                this.prompt.info("Starting the upgrade of the database...");
+                                await this._upgradeDb(file, to);
+                            } else if (enter === "no") {
+                                this.prompt.info("You cancelled the upgrade of the database. Stopping...");
+                                this.shutdown(3);
+                            } else {
+                                this.prompt.warn("Please enter either \"yes\" or \"no\".");
+                            }
+                        })
+
+                        this.interactiveTerm.on("quit", () => {
+                            this.shutdown(3)
+                        })
+
+                        this.interactiveTerm.listen();
+
+                        this.prompt.info("If your destination file " + to + " exists, it'll be erased.");
+                        this.prompt.info("The database " + file + " will not be affected by the upgrade.");
+                        this.prompt.info("Please confirm the upgrading of the database by entering \"yes\" or \"no\" in lowercase then press Enter.");
+                    }
+                } else {
+                    this.prompt.warn("No value given to --upgrade-database.");
+                }
+                return;
+            }
+
+            if (el.indexOf("--hot-reload") === 0 || el.indexOf("-hr") === 0)
+                if (el.split("=").length > 0)
+                    this.prompt.debug("Hot-Reload enabled on " + ModuleExporter.watch(el.split("=")[1]))
+                else
+                    this.prompt.debug("Hot-Reload enabled on " + ModuleExporter.watch())
+
+            if (el === "--debug-script") {
+                this.on("ready", () => {
+                    require("fs").readFile("./debug-script.js", "utf8", (err, data) => {
+                        this._eval(data);
+                        this.prompt.info("Debug-script loaded.");
+                    });
+                })
+            }
+
+            if (el === "--no-colors" || el === "-nc")
+                this.prompt.colors = false;
+
+            if (el === "--quick-crash" || el === "-qc") {
+                process.on("uncaughtException", (e) => {
+                    console.log("uncaughtException", e);
+                    this.shutdown(-1);
+                });
+                process.on("unhandledRejection", (e) => {
+                    console.log("unhandledRejection", e)
+                    this.shutdown(-1);
+                });
+            }
+
+            if (el.indexOf("--custom-config") === 0) {
+                if (el.indexOf("--custom-config=") === 0) {
+                    let file = el.split("=")[1]
+
+                    if (!file || file === "")
+                        this.prompt.warn("No value given to --custom-config.");
+                    else {
+                        this.prompt.info("Loading " + file + " as config file.");
+                        await this.readConfig(file);
+                    }
+                } else {
+                    this.prompt.warn("Please define --custom-config. Example: --custom-config=DEBUG will load ./DEBUG.json as a config file")
+                }
+            }
+        }
+
+        await this._init();
+
+        this.launch();
+    }
+
+    /**
+     * Loads a config file.
+     * @param {String} file The config file (without the extension)
+     * @return {Promise}
+     */
+    readConfig(file) {
+        return new Promise((resolve, reject) => {
+            this.config = this.configMan.readConfigSync(file).defaults(DEFAULT_CONFIG)
+            resolve();
+        });
+    }
+
+    /**
+     * Switches steathly to an another config
+     * @param {String} file The config file (without the extension)
+     * @return {Promise}
+     */
+    switchToConfig(file) {
+        return new Promise(async (resolve, reject) => {
+            await this._triggerShutdownEvents()
+            this.config = (async (this.configMan.readConfig(file)).defaults(DEFAULT_CONFIG));
+            await this._triggerConfigEvents()
+            resolve();
+        });
+    }
+
+    /**
+     * Handles unhandled rejections. Logs everything.
+     * @param {Error} e Error
+     * @private
+     */
+    _unhandledRejection(e) {
+        this.prompt.error("Unhandled rejection", e);
+        this.emit("error", e);
+    }
+
+    /**
+     * Handles uncaught exceptions. Logs everything.
+     * @param {Error} e Error
+     * @private
+     */
+    _uncaughtException(e) {
+        this.prompt.error("Uncaught exception", e);
+        this.emit("error", e);
+    }
+
+    /**
+     * Triggers the config event for the instances.
+     * @private
+     * @return {Promise}
+     */
+    async _triggerConfigEvents() {
+        // Instances that need a config event.
+        // Sorted by their importance (from first to last)
+        const INSTANCES = [this.prompt, this.interactiveTerm, this.commandMan, this.configMan];
+
+        for (const el of INSTANCES) {
+            if (typeof el.configLoaded === "function")
+                await el.configLoaded(this, this.config);
+        }
+
+        for (const el of this.modules) {
+            if (typeof el.configLoaded === "function")
+                await el.configLoaded(this, this.config);
+        }
+    }
+
+    /**
+     * Triggers the shutdown event for the some instances.
+     * @private
+     * @return {Promise}
+     */
+    async _triggerShutdownEvents() {
+        // Instances that need a shutdown event.
+        // Sorted by their importance (from first to last)
+        const INSTANCES = [this.prompt, this.interactiveTerm, this.commandMan, this.configMan]
+
+        for (const el of INSTANCES) {
+            if (el.beforeShutdown && typeof el.beforeShutdown === "function")
+                await el.beforeShutdown(this);
+        }
+
+        for (const el of this.modules) {
+            if (typeof el.beforeShutdown === "function")
+                await el.beforeShutdown(this, this.config);
+        }
+    }
+
+    /**
+     * Makes the bot shutdown.
+     * @async
+     * @param {number?} reason
+     *  0/undefined - Unknown;
+     *  1 - User asked to;
+     * -1 - Exception.
+     *  3 - Database upgrade cancelled.
+     * @param {Error?} [e] The error.
+     */
+    async shutdown(reason, e) {
+        let reasonStr = "Unknown.";
+
+        switch(reason) {
+            case 1:
+                reasonStr = "User (via terminal: CTRL+C) asked to.";
+                break;
+            case 2:
+                reasonStr = "Shutdown command.";
+                break;
+            case 3:
+                reasonStr = "Database upgrade cancelled.";
+                break;
+            case -1:
+                reasonStr = "Fatal exception."
+        }
+
+        this.prompt.info("Shutdowning... Reason: " + reasonStr);
+
+        this.interactiveTerm.stop();
+
+
+
+        // Since instances aren't intialised when starting index.js with --upgrade-database, triggering shutdown events on them is useless.
+        if (reason !== 3) {
+            try { await this._triggerShutdownEvents(); } catch(e) { console.log("Error on trigger shutdown event", e)}
+            this.prompt.info("Saving config...");
+
+            let configSaveErr = false;
+            try {await this.config.save();} catch(e) {
+                configSaveErr = true;
+                this.prompt.error("Error while saving config", e);
+            }
+            if (!configSaveErr)
+                this.prompt.success("Config saved!");
+
+            this.prompt.info("Closing database...");
+
+            let dbClosingErr = false;
+            try {
+                await this.database.closePromise();
+            } catch(e) {
+                dbClosingErr = true;
+                this.prompt.error("Error while closing database", e);
+            }
+            if (!dbClosingErr)
+                this.prompt.success("Database closed!");
+        }
+
+        if (this.dC.token && this.dC.ping) {
+            this.prompt.info("Disconnecting from Discord...");
+            try {
+                await this.dC.destroy()
+                this.prompt.success("Successfully disconnected from Discord.");
+            } catch(e) {
+                this.prompt.error("Error while disconnecting from Discord")
+            }
+        }
+
+        process.exit(0);
+    }
+
+    /**
+     * Load all modules.
+     * Do not confound the ModuleExporter (which is for "librairies") and this, that will load Yuno's module.
+     * @async
+     */
+    async _loadModules() {
+        let files = await fsPromises.readdir("./src/modules");
+
+        for (const file of files) {
+            delete require.cache[require.resolve("./modules/" + file)]
+            let mod = require("./modules/" + file);
+            this.modules.push(mod);
+            await mod.init(this);
+            this.prompt.success("Module " + mod.modulename + " successfully loaded.");
+        }
+    }
+
+    /**
+     * Load all modules, with hot-reload enabled.
+     * Do not confound the ModuleExporter (which is for "librairies") and this, that will load Yuno's module.
+     * @async
+     */
+    async _loadModulesHR() {
+        let files = await fsPromises.readdir("./src/modules");
+
+        for (const file of files) {
+            delete require.cache[require.resolve("./modules/" + file)]
+            let mod = require("./modules/" + file);
+            this.modules.push(mod);
+            await mod.configLoaded(this, this.config);
+            await mod.init(this, true);
+            this.prompt.success("Module " + mod.modulename + " successfully loaded.");
+        }
+    }
+
+    /**
+     * Refreshes/restart a module
+     * @async
+     * @return null if the module has not been found, else, what .init has returned.
+     */
+    async _refreshMod(modulename) {
+        for(let i = 0; i < this.modules.length; i++) {
+            let el = this.modules[i];
+            if (el.modulename === modulename) {
+                this.prompt.success("Module " + modulename + " refreshed.");
+                await el.configLoaded(this, this.config);
+                return await el.init(this, true);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Everything went fine! Launch the bot!
+     */
+    async launch() {
+        if (!this.config)
+            if (typeof CUSTOM_CONFIG_FILE === "string")
+                this.readConfig(CUSTOM_CONFIG_FILE)
+            else
+                this.readConfig(DEFAULT_CONFIG_FILE);
+
+        this.prompt.success("Config loaded.");
+
+        this.prompt.info("Loading modules...");
+
+        await this._loadModules();
+
+        await this._triggerConfigEvents()
+
+
+
+        let dbPath = this.config.get("database"),
+            dbPassword = this.config.get("database.password"),
+            dbPragmas = this.config.get("database.pragmas"),
+            newDb;
+
+        try { await fsPromises.stat(dbPath) } catch(e) {
+            if (e.code === "ENOENT") {
+                newDb = true;
+                this.prompt.warn("Database " + dbPath + " as specified in the config doesn't exists. Creating a new one...");
+            }
+        }
+
+        // Build database options from config
+        let dbOptions = {};
+
+        if (dbPassword) {
+            dbOptions.password = dbPassword;
+        }
+
+        if (dbPragmas && typeof dbPragmas === "object") {
+            dbOptions.pragmas = {
+                walMode: dbPragmas.walMode === true,
+                performanceMode: dbPragmas.performanceMode === true,
+                memoryTemp: dbPragmas.memoryTemp === true
+            };
+
+            if (typeof dbPragmas.cacheSize === "number") {
+                dbOptions.pragmas.cacheSize = dbPragmas.cacheSize;
+            }
+
+            if (typeof dbPragmas.mmapSize === "number") {
+                dbOptions.pragmas.mmapSize = dbPragmas.mmapSize;
+            }
+        }
+
+        try {
+            await this.database.open(dbPath, dbOptions);
+            await DatabaseCommands.initDB(this.database, this, newDb);
+        } catch(e) {
+            this.prompt.error("Cannot open database.", e);
+            this.shutdown(-1);
             return;
         }
 
-        if (el.indexOf("--hot-reload") === 0 || el.indexOf("-hr") === 0)
-            if (el.split("=").length > 0)
-                this.prompt.debug("Hot-Reload enabled on " + ModuleExporter.watch(el.split("=")[1]))
-            else
-                this.prompt.debug("Hot-Reload enabled on " + ModuleExporter.watch())
-
-        if (el === "--debug-script") {
-            this.on("ready", function() {
-                require("fs").readFile("./debug-script.js", "utf8", (function(err, data) {
-                    this._eval(data);
-                    this.prompt.info("Debug-script loaded.");
-                }).bind(this));
-            })
-        }
-
-        if (el === "--no-colors" || el === "-nc")
-            this.prompt.colors = false;
-
-        if (el === "--quick-crash" || el === "-qc") {
-            process.on("uncaughtException", (function(e) {
-                console.log("uncaughtException", e);
-                this.shutdown(-1);
-            }).bind(this));
-            process.on("unhandledRejection", (function(e) {
-                console.log("unhandledRejection", e)
-                this.shutdown(-1);
-            }).bind(this));
-        }
-
-        if (el.indexOf("--custom-config") === 0) {
-            if (el.indexOf("--custom-config=") === 0) {
-                let file = el.split("=")[1]
-
-                if (!file || file === "")
-                    this.prompt.warn("No value given to --custom-config.");
-                else {
-                    this.prompt.info("Loading " + file + " as config file.");
-                    await this.readConfig(file);
-                }
-            } else {
-                this.prompt.warn("Please define --custom-config. Example: --custom-config=DEBUG will load ./DEBUG.json as a config file")
+        // Log database status
+        if (this.database.isEncrypted) {
+            this.prompt.success("SQLite database opened with encryption enabled.");
+        } else {
+            this.prompt.success("SQLite database opened.");
+            if (dbPassword && !this.database.isEncryptionAvailable()) {
+                this.prompt.warn("Database encryption was requested but @journeyapps/sqlcipher is not installed.");
             }
         }
-    }
 
-    await this._init();
-
-    this.launch();
-}
-
-/**
- * Loads a config file.
- * @param {String} file The config file (without the extension)
- * @return {Promise}
- */
-Yuno.prototype.readConfig = function(file) {
-    return new Promise((function(resolve, reject) {
-        this.config = this.configMan.readConfigSync(file).defaults(DEFAULT_CONFIG)
-        resolve();
-    }).bind(this));
-}
-
-/**
- * Switches steathly to an another config
- * @param {String} file The config file (without the extension)
- * @return {Promise}
- */
-Yuno.prototype.switchToConfig = function(file) {
-    return new Promise((async function(resolve, reject) {
-        await this._triggerShutdownEvents()
-        this.config = (async (this.configMan.readConfig(file)).defaults(DEFAULT_CONFIG));
-        await this._triggerConfigEvents()
-        resolve();
-    }).bind(this));
-}
-
-/**
- * Handles unhandled rejections. Logs everything.
- * @param {Error} e Error
- * @private
- */
-Yuno.prototype._unhandledRejection = function(e) {
-    this.prompt.error("Unhandled rejection", e);
-    this.emit("error", e);
-}
-
-/**
- * Handles uncaught exceptions. Logs everything.
- * @param {Error} e Error
- * @private
- */
-Yuno.prototype._uncaughtException = function(e) {
-    this.prompt.error("Uncaught exception", e);
-    this.emit("error", e);
-}
-
-/**
- * Triggers the config event for the instances.
- * @private
- * @return {Promise}
- */
-Yuno.prototype._triggerConfigEvents = async function() {
-    // Instances that need a config event.
-    // Sorted by their importance (from first to last)
-    const INSTANCES = [this.prompt, this.interactiveTerm, this.commandMan, this.configMan];
-
-    for (const el of INSTANCES) {
-        if (typeof el.configLoaded === "function")
-            await el.configLoaded(this, this.config);
-    }
-
-    for (const el of this.modules) {
-        if (typeof el.configLoaded === "function")
-            await el.configLoaded(this, this.config);
-    }
-}
-
-/**
- * Triggers the shutdown event for the some instances.
- * @private
- * @return {Promise}
- */
-Yuno.prototype._triggerShutdownEvents = async function() {
-    // Instances that need a shutdown event.
-    // Sorted by their importance (from first to last)
-    const INSTANCES = [this.prompt, this.interactiveTerm, this.commandMan, this.configMan]
-
-    for (const el of INSTANCES) {
-        if (el.beforeShutdown && typeof el.beforeShutdown === "function")
-            await el.beforeShutdown(this);
-    }
-
-    for (const el of this.modules) {
-        if (typeof el.beforeShutdown === "function")
-            await el.beforeShutdown(this, this.config);
-    }
-}
-
-/**
- * Makes the bot shutdown.
- * @async
- * @param {number?} reason
- *  0/undefined - Unknown;
- *  1 - User asked to;
- * -1 - Exception.
- *  3 - Database upgrade cancelled.
- * @param {Error?} [e] The error.
- */
-Yuno.prototype.shutdown = async function(reason, e) {
-    let reasonStr = "Unknown.";
-
-    switch(reason) {
-        case 1:
-            reasonStr = "User (via terminal: CTRL+C) asked to.";
-            break;
-        case 2:
-            reasonStr = "Shutdown command.";
-            break;
-        case 3:
-            reasonStr = "Database upgrade cancelled.";
-            break;
-        case -1:
-            reasonStr = "Fatal exception."
-    }
-
-    this.prompt.info("Shutdowning... Reason: " + reasonStr);
-
-    this.interactiveTerm.stop();
-
-
-
-    // Since instances aren't intialised when starting index.js with --upgrade-database, triggering shutdown events on them is useless.
-    if (reason !== 3) {
-        try { await this._triggerShutdownEvents(); } catch(e) { console.log("Error on trigger shutdown event", e)}
-        this.prompt.info("Saving config...");
-    
-        let configSaveErr = false;
-        try {await this.config.save();} catch(e) {
-            configSaveErr = true;
-            this.prompt.error("Error while saving config", e);
+        if (dbPragmas && (dbPragmas.walMode || dbPragmas.performanceMode)) {
+            this.prompt.info("Database optimizations applied.");
         }
-        if (!configSaveErr)
-            this.prompt.success("Config saved!");
 
-        this.prompt.info("Closing database...");
+        this.emit("sqlite-opened");
 
-        let dbClosingErr = false;
+        this.prompt.info("Connecting to Discord...");
         try {
-            await this.database.closePromise();
+            if (typeof CUSTOM_TOKEN === "string")
+                this.config.set("discord.token", CUSTOM_TOKEN).save();
+            let token = this.config.get("discord.token");
+            await this.discordClient.login(token);
         } catch(e) {
-            dbClosingErr = true;
-            this.prompt.error("Error while closing database", e);
-        }
-        if (!dbClosingErr)
-            this.prompt.success("Database closed!");
-    }
-
-    if (this.dC.token && this.dC.ping) {
-        this.prompt.info("Disconnecting from Discord...");
-        try {
-            await this.dC.destroy()
-            this.prompt.success("Successfully disconnected from Discord.");
-        } catch(e) {
-            this.prompt.error("Error while disconnecting from Discord")
-        }
-    }
-
-    process.exit(0);
-}
-
-/**
- * Load all modules.
- * Do not confound the ModuleExporter (which is for "librairies") and this, that will load Yuno's module.
- * @async
- */
-Yuno.prototype._loadModules = async function() {
-    let files = await fsPromises.readdir("./src/modules");
-
-    for (const file of files) {
-        delete require.cache[require.resolve("./modules/" + file)]
-        let mod = require("./modules/" + file);
-        this.modules.push(mod);
-        await mod.init(this);
-        this.prompt.success("Module " + mod.modulename + " successfully loaded.");
-    }
-}
-
-/**
- * Load all modules, with hot-reload enabled.
- * Do not confound the ModuleExporter (which is for "librairies") and this, that will load Yuno's module.
- * @async
- */
-Yuno.prototype._loadModulesHR = async function() {
-    let files = await fsPromises.readdir("./src/modules");
-
-    for (const file of files) {
-        delete require.cache[require.resolve("./modules/" + file)]
-        let mod = require("./modules/" + file);
-        this.modules.push(mod);
-        await mod.configLoaded(this, this.config);
-        await mod.init(this, true);
-        this.prompt.success("Module " + mod.modulename + " successfully loaded.");
-    }
-}
-
-/**
- * Refreshes/restart a module
- * @async
- * @return null if the module has not been found, else, what .init has returned.
- */
-Yuno.prototype._refreshMod = async function(modulename) {
-    for(let i = 0; i < this.modules.length; i++) {
-        let el = this.modules[i];
-        if (el.modulename === modulename) {
-            this.prompt.success("Module " + modulename + " refreshed.");
-            await el.configLoaded(this, this.config);
-            return await el.init(this, true);
-        }
-    }
-    return null;
-}
-
-/**
- * Everything went fine! Launch the bot!
- */
-Yuno.prototype.launch = async function() {
-    if (!this.config)
-        if (typeof CUSTOM_CONFIG_FILE === "string")
-            this.readConfig(CUSTOM_CONFIG_FILE)
-        else
-            this.readConfig(DEFAULT_CONFIG_FILE);
-
-    this.prompt.success("Config loaded.");
-
-    this.prompt.info("Loading modules...");
-
-    await this._loadModules();
-
-    await this._triggerConfigEvents()
-
-
-
-    let dbPath = this.config.get("database"),
-        dbPassword = this.config.get("database.password"),
-        dbPragmas = this.config.get("database.pragmas"),
-        newDb;
-
-    try { await fsPromises.stat(dbPath) } catch(e) {
-        if (e.code === "ENOENT") {
-            newDb = true;
-            this.prompt.warn("Database " + dbPath + " as specified in the config doesn't exists. Creating a new one...");
-        }
-    }
-
-    // Build database options from config
-    let dbOptions = {};
-
-    if (dbPassword) {
-        dbOptions.password = dbPassword;
-    }
-
-    if (dbPragmas && typeof dbPragmas === "object") {
-        dbOptions.pragmas = {
-            walMode: dbPragmas.walMode === true,
-            performanceMode: dbPragmas.performanceMode === true,
-            memoryTemp: dbPragmas.memoryTemp === true
-        };
-
-        if (typeof dbPragmas.cacheSize === "number") {
-            dbOptions.pragmas.cacheSize = dbPragmas.cacheSize;
+            if (e.message.indexOf("invalid token") > -1 || e.message.indexOf("Incorrect login") > -1)
+                throw new Error("Error while connecting to Discord. Incorrect token.")
+            throw e;
         }
 
-        if (typeof dbPragmas.mmapSize === "number") {
-            dbOptions.pragmas.mmapSize = dbPragmas.mmapSize;
-        }
+        this.emit("discord-connected", this);
+        this.prompt.success("Successfully connected to Discord as " + this.dC.user.tag);
+        this.prompt.info("Bot launched.");
     }
-
-    try {
-        await this.database.open(dbPath, dbOptions);
-        await DatabaseCommands.initDB(this.database, this, newDb);
-    } catch(e) {
-        this.prompt.error("Cannot open database.", e);
-        this.shutdown(-1);
-        return;
-    }
-
-    // Log database status
-    if (this.database.isEncrypted) {
-        this.prompt.success("SQLite database opened with encryption enabled.");
-    } else {
-        this.prompt.success("SQLite database opened.");
-        if (dbPassword && !this.database.isEncryptionAvailable()) {
-            this.prompt.warn("Database encryption was requested but @journeyapps/sqlcipher is not installed.");
-        }
-    }
-
-    if (dbPragmas && (dbPragmas.walMode || dbPragmas.performanceMode)) {
-        this.prompt.info("Database optimizations applied.");
-    }
-
-    this.emit("sqlite-opened");
-
-    this.prompt.info("Connecting to Discord...");
-    try {
-        if (typeof CUSTOM_TOKEN === "string")
-            this.config.set("discord.token", CUSTOM_TOKEN).save();
-        let token = this.config.get("discord.token");
-        await this.discordClient.login(token);
-    } catch(e) {
-        if (e.message.indexOf("invalid token") > -1 || e.message.indexOf("Incorrect login") > -1)
-            throw new Error("Error while connecting to Discord. Incorrect token.")
-        throw e;
-    }
-
-    this.emit("discord-connected", this);
-    this.prompt.success("Successfully connected to Discord as " + this.dC.user.tag);
-    this.prompt.info("Bot launched.");
 }
 
 module.exports = Yuno;

--- a/src/commands/anime.js
+++ b/src/commands/anime.js
@@ -36,22 +36,22 @@ module.exports.run = async function(yuno, author, args, msg) {
                 { name: 'Type', value: item.type, inline: true },
                 { name: 'Status', value: item.status, inline: true },
                 { name: 'Start date', value: item.start_date === '0000-00-00' ? 'TBD' : item.start_date, inline: true },
-                { name: 'End date', value: item.end_date === '0000-00-00' ? 'TBD' : item_end_date, inline : true },
+                { name: 'End date', value: item.end_date === '0000-00-00' ? 'TBD' : item.end_date, inline : true },
                 { name: 'Episodes', value: item.episodes === 0 ? 'TBD' : item.episodes, inline: true },
                 { name: 'Score', value: `${item.score}`, inline: true }
             ])
             .setDescription(Yuno.Util.cleanSynopsis(he.decode(item.synopsis), item.id, 'anime'))
             .setThumbnail(item.image)
-            .setFooter({ text: `Use the reaction to browse | Page1${res.length}`});
+            .setFooter({ text: `Use the reactions to browse | Page 1/${res.length}`});
         return embed;
     }));
     let currentPage = 0;
     const pageMsg = await msg.channel.send({embeds: [res[0]]});
     await pageMsg.react('◀');
     await pageMsg.react('▶');
-    pageMsg.React('X');
+    await pageMsg.react('❌');
 
-    const RC = new ReactionCollectior(pageMsg, (r) => r.user.last().id === msg.author.id);
+    const RC = new ReactionCollector(pageMsg, { filter: (r, user) => user.id === msg.author.id });
 
     const switchPages = (direction) => {
         if (['◀', '▶'].includes(direction)) {
@@ -73,7 +73,7 @@ module.exports.run = async function(yuno, author, args, msg) {
     });
 
     setTimeout(() => {
-        if (!Rc.ended) {
+        if (!RC.ended) {
             switchPages('❌');
         }
     }, 120000);

--- a/src/commands/exportbans.js
+++ b/src/commands/exportbans.js
@@ -15,7 +15,7 @@
     You should have received a copy of the GNU Affero General Public License
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
-const fs = require("fs");
+const fs = require("fs").promises;
 const {PermissionsBitField} = require("discord.js");
 
 module.exports.run = async function(yuno, author, args, msg) {
@@ -71,13 +71,12 @@ module.exports.run = async function(yuno, author, args, msg) {
         const banstr = JSON.stringify(allBannedUserIds);
 
         // Write to file
-        fs.writeFile("./BANS-" + guid + ".txt", banstr, async (err) => {
-            if (err) {
-                await statusMsg.edit("Error while saving bans :( :" + err.code);
-            } else {
-                await statusMsg.edit(`Bans exported successfully! **${allBannedUserIds.length}** bans saved with Guild ID: ${guid}`);
-            }
-        });
+        try {
+            await fs.writeFile(`./BANS-${guid}.txt`, banstr);
+            await statusMsg.edit(`Bans exported successfully! **${allBannedUserIds.length}** bans saved with Guild ID: ${guid}`);
+        } catch (err) {
+            await statusMsg.edit(`Error while saving bans :( :${err.code}`);
+        }
     } catch(e) {
         msg.channel.send("Error while fetching bans: " + e.message);
         console.error("Export bans error:", e);

--- a/src/commands/importbans.js
+++ b/src/commands/importbans.js
@@ -16,7 +16,7 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
-let fs = require("fs");
+const fs = require("fs").promises;
 
 module.exports.run = async function(yuno, author, args, msg) {
     if (!args[0])
@@ -30,96 +30,98 @@ module.exports.run = async function(yuno, author, args, msg) {
         return msg.channel.send(":negative_squared_cross_mark: Invalid guild ID. Guild IDs should only contain numbers.");
     }
 
-    fs.readFile("./BANS-" + guid + ".txt", async (err, data) => {
-        if (err)
-            return msg.channel.send("Error while retrieving bans: " + err.code);
+    let data;
+    try {
+        data = await fs.readFile(`./BANS-${guid}.txt`, "utf8");
+    } catch (err) {
+        return msg.channel.send(`Error while retrieving bans: ${err.code}`);
+    }
 
-        console.log("[BanMSystem] Applying bans...");
-        try {
-            const bans = JSON.parse(data);
+    console.log("[BanMSystem] Applying bans...");
+    try {
+        const bans = JSON.parse(data);
 
-            if (!Array.isArray(bans) || bans.length === 0) {
-                return msg.channel.send("No bans found in the file or invalid format.");
-            }
+        if (!Array.isArray(bans) || bans.length === 0) {
+            return msg.channel.send("No bans found in the file or invalid format.");
+        }
 
-            const statusMsg = await msg.channel.send(`:hourglass: Starting ban import for ${bans.length} users... This may take a while.`);
+        const statusMsg = await msg.channel.send(`:hourglass: Starting ban import for ${bans.length} users... This may take a while.`);
 
-            // Discord.js v14 doesn't have bulkCreate, we need to ban individually
-            // Process in batches to avoid rate limits
-            const batchSize = 5; // Small batch to be safe with rate limits
-            const delayBetweenBans = 1000; // 1 second delay between each ban
-            const delayBetweenBatches = 5000; // 5 second delay between batches
-            
-            let totalBanned = 0;
-            let totalFailed = 0;
-            let totalAlreadyBanned = 0;
-            let processedCount = 0;
-            const totalBatches = Math.ceil(bans.length / batchSize);
+        // Discord.js v14 doesn't have bulkCreate, we need to ban individually
+        // Process in batches to avoid rate limits
+        const batchSize = 5; // Small batch to be safe with rate limits
+        const delayBetweenBans = 1000; // 1 second delay between each ban
+        const delayBetweenBatches = 5000; // 5 second delay between batches
 
-            // Process bans in small batches
-            for (let i = 0; i < bans.length; i += batchSize) {
-                const batch = bans.slice(i, i + batchSize);
-                const batchNum = Math.floor(i / batchSize) + 1;
+        let totalBanned = 0;
+        let totalFailed = 0;
+        let totalAlreadyBanned = 0;
+        let processedCount = 0;
+        const totalBatches = Math.ceil(bans.length / batchSize);
 
-                // Update status at start of each batch
-                await statusMsg.edit(
-                    `:hourglass: Processing ban import... Batch ${batchNum}/${totalBatches}\n` +
-                    `Progress: ${processedCount}/${bans.length} (${Math.round((processedCount/bans.length)*100)}%)\n` +
-                    `Banned: ${totalBanned} | Already banned: ${totalAlreadyBanned} | Failed: ${totalFailed}`
-                );
+        // Process bans in small batches
+        for (let i = 0; i < bans.length; i += batchSize) {
+            const batch = bans.slice(i, i + batchSize);
+            const batchNum = Math.floor(i / batchSize) + 1;
 
-                // Process each ban in the batch with individual delays
-                for (const userId of batch) {
-                    try {
-                        await msg.guild.members.ban(userId, {
-                            deleteMessageSeconds: 0,
-                            reason: "Ban import from saved banlist"
-                        });
-                        totalBanned++;
-                        console.log(`[BanMSystem] Banned user ${userId}`);
-                    } catch(error) {
-                        // Check if already banned
-                        if (error.code === 10026) { // Unknown Ban (user not banned)
-                            totalAlreadyBanned++;
-                        } else if (error.message.includes("already banned")) {
-                            totalAlreadyBanned++;
-                        } else {
-                            totalFailed++;
-                            console.error(`[BanMSystem] Failed to ban ${userId}:`, error.message);
-                        }
-                    }
-                    
-                    processedCount++;
-
-                    // Delay between individual bans
-                    if (processedCount < bans.length) {
-                        await new Promise(resolve => setTimeout(resolve, delayBetweenBans));
-                    }
-                }
-
-                // Longer delay between batches
-                if (i + batchSize < bans.length) {
-                    await new Promise(resolve => setTimeout(resolve, delayBetweenBatches));
-                }
-            }
-
-            console.log(`[BanMSystem] Import complete. Banned: ${totalBanned}, Already banned: ${totalAlreadyBanned}, Failed: ${totalFailed}`);
-
-            // Send final result
+            // Update status at start of each batch
             await statusMsg.edit(
-                `✅ Ban import complete!\n` +
-                `:white_check_mark: Successfully banned: **${totalBanned}**\n` +
-                `:information_source: Already banned: **${totalAlreadyBanned}**\n` +
-                `:negative_squared_cross_mark: Failed: **${totalFailed}**\n` +
-                `Processed **${bans.length}** users in ${totalBatches} batches\n\n` +
-                `⚠️ Note: This process took longer due to Discord rate limits. All bans have been applied.`
+                `:hourglass: Processing ban import... Batch ${batchNum}/${totalBatches}\n` +
+                `Progress: ${processedCount}/${bans.length} (${Math.round((processedCount/bans.length)*100)}%)\n` +
+                `Banned: ${totalBanned} | Already banned: ${totalAlreadyBanned} | Failed: ${totalFailed}`
             );
 
-        } catch(e) {
-            console.log("[BanMSystem] Bans weren't saved as JSON or bulk ban failed. Error: " + e.message);
-            msg.channel.send("Error during ban import: " + e.message);
+            // Process each ban in the batch with individual delays
+            for (const userId of batch) {
+                try {
+                    await msg.guild.members.ban(userId, {
+                        deleteMessageSeconds: 0,
+                        reason: "Ban import from saved banlist"
+                    });
+                    totalBanned++;
+                    console.log(`[BanMSystem] Banned user ${userId}`);
+                } catch (error) {
+                    // Check if already banned
+                    if (error.code === 10026) { // Unknown Ban (user not banned)
+                        totalAlreadyBanned++;
+                    } else if (error.message.includes("already banned")) {
+                        totalAlreadyBanned++;
+                    } else {
+                        totalFailed++;
+                        console.error(`[BanMSystem] Failed to ban ${userId}:`, error.message);
+                    }
+                }
+
+                processedCount++;
+
+                // Delay between individual bans
+                if (processedCount < bans.length) {
+                    await new Promise(resolve => setTimeout(resolve, delayBetweenBans));
+                }
+            }
+
+            // Longer delay between batches
+            if (i + batchSize < bans.length) {
+                await new Promise(resolve => setTimeout(resolve, delayBetweenBatches));
+            }
         }
-    })
+
+        console.log(`[BanMSystem] Import complete. Banned: ${totalBanned}, Already banned: ${totalAlreadyBanned}, Failed: ${totalFailed}`);
+
+        // Send final result
+        await statusMsg.edit(
+            `Ban import complete!\n` +
+            `:white_check_mark: Successfully banned: **${totalBanned}**\n` +
+            `:information_source: Already banned: **${totalAlreadyBanned}**\n` +
+            `:negative_squared_cross_mark: Failed: **${totalFailed}**\n` +
+            `Processed **${bans.length}** users in ${totalBatches} batches\n\n` +
+            `Note: This process took longer due to Discord rate limits. All bans have been applied.`
+        );
+
+    } catch (e) {
+        console.log(`[BanMSystem] Bans weren't saved as JSON or bulk ban failed. Error: ${e.message}`);
+        msg.channel.send(`Error during ban import: ${e.message}`);
+    }
 };
 
 module.exports.about = {

--- a/src/lib/commandManager.js
+++ b/src/lib/commandManager.js
@@ -16,9 +16,8 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
-const Util = require("util"),
-    EventEmitter = require("events"),
-    fs = require("fs"),
+const EventEmitter = require("events"),
+    fsPromises = require("fs").promises,
     path = require("path"),
     { GuildMember, PermissionsBitField } = require("discord.js");
 
@@ -28,100 +27,89 @@ let insufficientPermissionsMessage = "Insufficient permissions.",
 /**
  * A command manager.
  * Parses commands, triggers them, returns error messages, etc...
- * @param {String?} [directory] Path to the commands directory. Defaults to src/commands
- * @constructor
- * @prop {String} directory The directory where all commands are located
- * @prop {Object} commands All the commands. Key as command name and value as the module.
  * @extends EventEmitter
  */
-let CommandManager = function(directory) {
-    if (typeof directory !== "string")
-        directory = path.resolve(__dirname, "../commands");
+class CommandManager extends EventEmitter {
+    /**
+     * @param {String} [directory] Path to the commands directory. Defaults to src/commands
+     */
+    constructor(directory) {
+        super();
 
-    this.directory = directory;
+        if (typeof directory !== "string")
+            directory = path.resolve(__dirname, "../commands");
 
-    this.commands = {};
-}
+        this.directory = directory;
+        this.commands = {};
+    }
 
-Util.inherits(CommandManager, EventEmitter)
+    /**
+     * Returns the directory for backup
+     * @return {String}
+     */
+    backup() {
+        return this.directory;
+    }
 
-CommandManager.prototype.backup = function() {
-    return this.directory;
-}
+    /**
+     * Inits the command manager by reading all commands in the specified directory.
+     */
+    async init() {
+        const files = await fsPromises.readdir(this.directory, "utf8");
+        let cmdLoaded = 0;
 
-/**
- * Inits the command manager by reading all commands in the specified directory.
- */
-CommandManager.prototype.init = function() {
-    return new Promise((function(resolve, reject) {
-        fs.readdir(this.directory, "utf8", (async function(err, files) {
-            let cmdLoaded = 0;
+        for (const file of files) {
+            await this.readCommand(file);
+            cmdLoaded++;
+        }
 
-            if (!err)
-                for(let i = 0; i < files.length; i++) {
-                    await this.readCommand(files[i]);
-                    cmdLoaded++;
-                }
-            else
-                reject(err);
+        prompt.info(`A total of ${cmdLoaded} command(s) has been loaded.`);
+        this.emit("loaded");
+    }
 
-            prompt.info("A total of " + cmdLoaded + " command(s) has been loaded.");
-            this.emit("loaded");
-            resolve();
-        }.bind(this)));
-    }).bind(this));
-}
+    /**
+     * Clears the cache of require for a specified file and resolve the file's path.
+     * @param {String} file Path to the file.
+     * @private
+     * @returns {String} The path to the file, resolved.
+     */
+    _clearCache(file) {
+        if (file.indexOf(".js"))
+            file = file.substring(0, file.lastIndexOf(".js"));
 
-/**
- * Clears the cache of require for a specified file and resolve the file's path.
- * @param {String} file Path to the file.
- * @private
- * @returns {String} The path to the file, resolved.
- */
-CommandManager.prototype._clearCache = function(file) {
-    if (file.indexOf(".js"))
-        file = file.substring(0, file.lastIndexOf(".js"));
+        file = `${this.directory}/${file}`;
+        file = require.resolve(file);
 
-    file = this.directory + "/" + file;
+        if (require.cache[file])
+            delete require.cache[file];
 
-    file = require.resolve(file);
+        return file;
+    }
 
-    if (require.cache[file])
-        delete require.cache[file];
+    /**
+     * Returns only the filename of a full path
+     * @param {String} file
+     * @return {String} The file name.
+     */
+    _onlyFileName(file) {
+        const extensionIndex = file.lastIndexOf(".");
+        const extension = file.substring(extensionIndex, file.length);
+        return path.basename(file, extension);
+    }
 
-    return file;
-}
+    /**
+     * Reads a command from a file (module-like.)
+     * @param {String} file Path to the file.
+     * @returns {Promise}
+     */
+    async readCommand(file) {
+        file = this._clearCache(file);
 
-/**
- * Returns only the filename of a full path
- * @param {String} file
- * @return {String} The file name.
- */
-CommandManager.prototype._onlyFileName = function(file) {
-    let extension = file.lastIndexOf(".");
-
-    extension = file.substring(extension, file.length);
-
-    return path.basename(file, extension)
-}
-
-/**
- * Reads a command from a file (module-like.);
- * @param {String} file Path to the file.
- * @returns {Promise}
- */
-CommandManager.prototype.readCommand = function(file) {
-    let _fs = fs;
-
-    file = this._clearCache(file);
-
-
-    return new Promise((function(resolve, reject) {
         let commandModule;
         try {
             commandModule = require(file);
-        } catch(e) {
-            reject(e);
+        } catch (e) {
+            throw e;
         }
 
         if (!commandModule.about || !commandModule.about.command || typeof commandModule.about.command !== "string") {
@@ -129,13 +117,13 @@ CommandManager.prototype.readCommand = function(file) {
                 commandModule.about.command = this._onlyFileName(file);
             else
                 commandModule.about = {
-                    "command": this._onlyFileName(file)
-                }
+                    command: this._onlyFileName(file)
+                };
         }
 
         // check for duplicates
         if (this._commandExists(commandModule.about.command))
-            reject(new Error("Tried to push a command called " + commandModule.about.command + " but it already exists."));
+            throw new Error(`Tried to push a command called ${commandModule.about.command} but it already exists.`);
 
         this.commands[commandModule.about.command] = commandModule;
 
@@ -143,239 +131,232 @@ CommandManager.prototype.readCommand = function(file) {
 
         if (typeof aliases === "string")
             aliases = [aliases];
-        if (aliases instanceof Array) {
-            for(let i = 0; i < aliases.length; i++)
-                this.commands[aliases[i]] = commandModule;
+        if (Array.isArray(aliases)) {
+            for (const alias of aliases)
+                this.commands[alias] = commandModule;
         }
 
-        prompt.info("Command " + commandModule.about.command + " has been loaded.");
-
-        resolve();
-    }).bind(this));
-}
-
-/**
- * Parse the command, returning an object containing the command and the args.
- * @param {String} command
- * @returns {Object}
- */
-CommandManager.prototype._parse = function(command) {
-    let mainCommandSubstr = command.indexOf(" "),
-        mainCommand = command.substring(0, mainCommandSubstr > -1 ? mainCommandSubstr : command.length).toLowerCase(),
-        args = command.substring(mainCommandSubstr > -1 ? mainCommandSubstr : command.length, command.length).trim().match(/[^\s"]+|"([^"]*)"/g);
-
-    if (args === null ||args.length === 1 && args[0] === "")
-        args = [];
-
-    for(let i = 0; i < args.length; i++) {
-        let el = args[i];
-
-        if (el.charAt(0) === "\"" && el.charAt(el.length - 1) === "\"")
-            args[i] = el.substring(1, el.length -1)
-    }
-    
-    return {
-        "command": mainCommand,
-        "args": args
-    }
-}
-
-/**
- * Returns either if a command exists or note
- * @param {String} command
- * @return {boolean}
- * @private
- */
-CommandManager.prototype._commandExists = function(command) {
-    return Object.prototype.hasOwnProperty.call(this.commands, command);
-}
-
-/**
- * Triggered when the main (Yuno's) config is loaded.
- * @param {Yuno} Yuno The yuno's instance
- * @param {Config} config The configuration
- */
-CommandManager.prototype.configLoaded = function(Yuno, config) {
-    let insufficientPermissionsMessage_ = config.get("chat.insufficient-permissions"),
-        masterusers_ = config.get("commands.master-users");
-
-    if (typeof insufficientPermissionsMessage_ === "string")
-        insufficientPermissionsMessage = insufficientPermissionsMessage_;
-
-    if (typeof masterusers_ === "string")
-        masterusers_ = [masterusers_];
-
-    if (masterusers_ instanceof Array)
-        masterusers = masterusers_;
-}
-
-/**
- * Returns whether a user is a master user or not, from his id.
- * @param {String} userId The user's id
- */
-CommandManager.prototype._isUserMaster = function(userId) {
-    return masterusers.includes(userId);
-}
-
-/**
- * Converts v12 SCREAMING_SNAKE_CASE permission names to v14 PascalCase
- * @param {String} permission The permission name to convert
- * @private
- * @return {String}
- */
-CommandManager.prototype._convertPermissionName = function(permission) {
-    // If already in PascalCase format, return as-is
-    if (permission === permission.toLowerCase() || !permission.includes('_')) {
-        return permission;
+        prompt.info(`Command ${commandModule.about.command} has been loaded.`);
     }
 
-    // Convert SCREAMING_SNAKE_CASE to PascalCase
-    return permission.split('_').map(word =>
-        word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()
-    ).join('');
-}
+    /**
+     * Parse the command, returning an object containing the command and the args.
+     * @param {String} command
+     * @returns {Object}
+     */
+    _parse(command) {
+        const mainCommandSubstr = command.indexOf(" ");
+        const mainCommand = command.substring(0, mainCommandSubstr > -1 ? mainCommandSubstr : command.length).toLowerCase();
+        let args = command.substring(mainCommandSubstr > -1 ? mainCommandSubstr : command.length, command.length).trim().match(/[^\s"]+|"([^"]*)"/g);
 
-/**
- * Returns whether the guild member has all given permissions
- * @param {GuildMember} member The guild member to check permissions.
- * @param {array|String} permissions The permissions to check.
- * @private
- * @return {boolean}
- */
-CommandManager.prototype._hasPermissions = function(member, permissions) {
-    if (typeof permissions !== "string" && !(permissions instanceof Array))
-        return true;
+        if (args === null || (args.length === 1 && args[0] === ""))
+            args = [];
 
-    if (permissions.length === 0)
-        return true;
+        for (let i = 0; i < args.length; i++) {
+            const el = args[i];
+            if (el.charAt(0) === "\"" && el.charAt(el.length - 1) === "\"")
+                args[i] = el.substring(1, el.length - 1);
+        }
 
-    if (typeof permissions === "string")
-        permissions = [permissions];
-
-    for(let i = 0; i < permissions.length; i++) {
-        // Convert v12 permission name to v14 format (SCREAMING_SNAKE_CASE to PascalCase)
-        const permissionName = this._convertPermissionName(permissions[i]);
-        const permissionFlag = PermissionsBitField.Flags[permissionName];
-
-        if (!permissionFlag || !member.permissions.has(permissionFlag))
-            return false;
+        return {
+            command: mainCommand,
+            args: args
+        };
     }
 
-    return true;
-}
+    /**
+     * Returns either if a command exists or not
+     * @param {String} command
+     * @return {boolean}
+     * @private
+     */
+    _commandExists(command) {
+        return Object.prototype.hasOwnProperty.call(this.commands, command);
+    }
 
-/**
- * Returns whether the command is DM possible or not
- * @param {String} command Command
- * @return {Boolean}
- */
-CommandManager.prototype.isDMCommand = function(command) {
-    let parsedCommand = this._parse(command);
+    /**
+     * Triggered when the main (Yuno's) config is loaded.
+     * @param {Yuno} Yuno The yuno's instance
+     * @param {Config} config The configuration
+     */
+    configLoaded(Yuno, config) {
+        const insufficientPermissionsMessage_ = config.get("chat.insufficient-permissions");
+        let masterusers_ = config.get("commands.master-users");
 
-    command = parsedCommand.command;
+        if (typeof insufficientPermissionsMessage_ === "string")
+            insufficientPermissionsMessage = insufficientPermissionsMessage_;
 
-    if (!this._commandExists(command))
-        return false;
+        if (typeof masterusers_ === "string")
+            masterusers_ = [masterusers_];
 
-    let commandObject = this.commands[command].about;
+        if (Array.isArray(masterusers_))
+            masterusers = masterusers_;
+    }
 
-    if (commandObject.isDMPossible === true)
-        if (commandObject.discord === true)
+    /**
+     * Returns whether a user is a master user or not, from his id.
+     * @param {String} userId The user's id
+     * @return {boolean}
+     */
+    _isUserMaster(userId) {
+        return masterusers.includes(userId);
+    }
+
+    /**
+     * Converts v12 SCREAMING_SNAKE_CASE permission names to v14 PascalCase
+     * @param {String} permission The permission name to convert
+     * @private
+     * @return {String}
+     */
+    _convertPermissionName(permission) {
+        // If already in PascalCase format, return as-is
+        if (permission === permission.toLowerCase() || !permission.includes('_')) {
+            return permission;
+        }
+
+        // Convert SCREAMING_SNAKE_CASE to PascalCase
+        return permission.split('_').map(word =>
+            word.charAt(0).toUpperCase() + word.slice(1).toLowerCase()
+        ).join('');
+    }
+
+    /**
+     * Returns whether the guild member has all given permissions
+     * @param {GuildMember} member The guild member to check permissions.
+     * @param {array|String} permissions The permissions to check.
+     * @private
+     * @return {boolean}
+     */
+    _hasPermissions(member, permissions) {
+        if (typeof permissions !== "string" && !Array.isArray(permissions))
             return true;
 
-    return false;
-}
+        if (permissions.length === 0)
+            return true;
 
-/**
- * Executes a command that works for DMs
- * @param {Yuno} Yuno The yuno's instance
- * @param {User} author The message author
- * @param {String} command 
- * @param {Message} msg 
- */
-CommandManager.prototype.executeDM = async function(Yuno, author, command, msg) {
-    let parsedCommand = this._parse(command),
-        commandObject = this.commands[command];
+        if (typeof permissions === "string")
+            permissions = [permissions];
 
-    if (!(commandObject.about.isDMPossible === true && commandObject.about.discord === true))
-        return;
+        for (const perm of permissions) {
+            // Convert v12 permission name to v14 format (SCREAMING_SNAKE_CASE to PascalCase)
+            const permissionName = this._convertPermissionName(perm);
+            const permissionFlag = PermissionsBitField.Flags[permissionName];
 
-    if (commandObject.about.onlyMasterUsers === true && !this._isUserMaster(author.id))
-        return;
+            if (!permissionFlag || !member.permissions.has(permissionFlag))
+                return false;
+        }
 
-    await commandObject.run(Yuno, author, parsedCommand.args, msg);
-}
-
-/**
- * Execute a command from its string (when called)
- * @param {Yuno} Yuno The yuno's instance
- * @param {null|GuildMember} source The triggerer of the command
- * @param {String} commandStr The string that was inputed.
- * @param {GuildMessage} message The message where the command is launched.
- * @returns {any} Null if no permission; else, the command result
- */
-CommandManager.prototype.execute = async function(Yuno, source, commandStr, message) {
-    if (commandStr === "" && source === null)
-        return prompt.info("Please at least, write something.");
-
-    let parsedCommand = this._parse(commandStr),
-        command = parsedCommand.command;
-
-    if (!this._commandExists(parsedCommand.command))
-        if (source === null)
-            return prompt.error("Command " + parsedCommand.command + " doesn't exists!");
-        else
-            return;
-
-    let commandObject = this.commands[command];
-
-    if (typeof commandObject.about.terminal === "boolean" && commandObject.about.terminal === false && source === null)
-        return prompt.error("The command " + command + " isn't accessible through terminal. Please use Discord's chat.");
-
-    if (source instanceof GuildMember || source === null) {
-        if (commandObject.about.discord === false && source instanceof GuildMember)
-            return;
-
-        if (commandObject.about.onlyMasterUsers === true && source !== null)
-            if (!this._isUserMaster(source.id))
-                return;
-
-        if (source === null || (source instanceof GuildMember && (this._isUserMaster(source.id) || this._hasPermissions(source, commandObject.about.requiredPermissions)))) {
-            let _error;
-            
-            //await message.channel.startTyping();
-            try { 
-                if (source === null && commandObject.runTerminal) {
-                    await commandObject.runTerminal(Yuno, parsedCommand.args);
-                } else {
-                    await commandObject.run(Yuno, source === null ? 0 : source, parsedCommand.args, message);
-                }
-            } catch(e) {
-                _error = e;
-            }
-            //await message.channel.stopTyping();
-            if (_error instanceof Error)
-                throw _error; // let yuno handle the error.
-        } else {			
-			//command execution failed due to insufficient permissions
-
-			if(commandObject.about.dangerous == true){
-				//otherwise, tell them they have insufficient permission.
-				return message.member.ban({
-					"deleteMessageSeconds": 86400,
-					"reason": "User tried to execute a command for which they are underprivileged."
-				});
-			}else{				
-				//otherwise, tell them they have insufficient permission.
-				return message.channel.send(
-					insufficientPermissionsMessage.replace("${author}", "<@!" + source.id + ">")
-				)
-			}
-		}
-    } else {
-        await commandObject.run(Yuno, source === null)
+        return true;
     }
 
+    /**
+     * Returns whether the command is DM possible or not
+     * @param {String} command Command
+     * @return {Boolean}
+     */
+    isDMCommand(command) {
+        const parsedCommand = this._parse(command);
+        command = parsedCommand.command;
+
+        if (!this._commandExists(command))
+            return false;
+
+        const commandObject = this.commands[command].about;
+
+        if (commandObject.isDMPossible === true && commandObject.discord === true)
+            return true;
+
+        return false;
+    }
+
+    /**
+     * Executes a command that works for DMs
+     * @param {Yuno} Yuno The yuno's instance
+     * @param {User} author The message author
+     * @param {String} command
+     * @param {Message} msg
+     */
+    async executeDM(Yuno, author, command, msg) {
+        const parsedCommand = this._parse(command);
+        const commandObject = this.commands[command];
+
+        if (!(commandObject.about.isDMPossible === true && commandObject.about.discord === true))
+            return;
+
+        if (commandObject.about.onlyMasterUsers === true && !this._isUserMaster(author.id))
+            return;
+
+        await commandObject.run(Yuno, author, parsedCommand.args, msg);
+    }
+
+    /**
+     * Execute a command from its string (when called)
+     * @param {Yuno} Yuno The yuno's instance
+     * @param {null|GuildMember} source The triggerer of the command
+     * @param {String} commandStr The string that was inputed.
+     * @param {GuildMessage} message The message where the command is launched.
+     * @returns {any} Null if no permission; else, the command result
+     */
+    async execute(Yuno, source, commandStr, message) {
+        if (commandStr === "" && source === null)
+            return prompt.info("Please at least, write something.");
+
+        const parsedCommand = this._parse(commandStr);
+        const command = parsedCommand.command;
+
+        if (!this._commandExists(parsedCommand.command)) {
+            if (source === null)
+                return prompt.error(`Command ${parsedCommand.command} doesn't exist!`);
+            else
+                return;
+        }
+
+        const commandObject = this.commands[command];
+
+        if (typeof commandObject.about.terminal === "boolean" && commandObject.about.terminal === false && source === null)
+            return prompt.error(`The command ${command} isn't accessible through terminal. Please use Discord's chat.`);
+
+        if (source instanceof GuildMember || source === null) {
+            if (commandObject.about.discord === false && source instanceof GuildMember)
+                return;
+
+            if (commandObject.about.onlyMasterUsers === true && source !== null) {
+                if (!this._isUserMaster(source.id))
+                    return;
+            }
+
+            if (source === null || (source instanceof GuildMember && (this._isUserMaster(source.id) || this._hasPermissions(source, commandObject.about.requiredPermissions)))) {
+                let _error;
+
+                try {
+                    if (source === null && commandObject.runTerminal) {
+                        await commandObject.runTerminal(Yuno, parsedCommand.args);
+                    } else {
+                        await commandObject.run(Yuno, source === null ? 0 : source, parsedCommand.args, message);
+                    }
+                } catch (e) {
+                    _error = e;
+                }
+
+                if (_error instanceof Error)
+                    throw _error; // let yuno handle the error.
+            } else {
+                // command execution failed due to insufficient permissions
+                if (commandObject.about.dangerous === true) {
+                    return message.member.ban({
+                        deleteMessageSeconds: 86400,
+                        reason: "User tried to execute a command for which they are underprivileged."
+                    });
+                } else {
+                    return message.channel.send(
+                        insufficientPermissionsMessage.replace("${author}", `<@!${source.id}>`)
+                    );
+                }
+            }
+        } else {
+            await commandObject.run(Yuno, source === null);
+        }
+    }
 }
 
 module.exports = CommandManager;

--- a/src/lib/prompt.js
+++ b/src/lib/prompt.js
@@ -16,8 +16,7 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
-const Util = require("util"),
-    readline = require("readline"),
+const readline = require("readline"),
 
     GROUPWIDTH = 10;
 
@@ -33,40 +32,311 @@ let instance = null,
  * @prop {Object} groupColors The colors for the group.
  * @prop {boolean} showTime Show time in logs.
  * @prop {boolean} colors Defines if colors have to be logged.
- * @constructor
  */
-let Prompt = function(settings) {
-    this.hiddenGroups =
-        typeof settings === "object" && settings.hasOwnProperty("hiddenGroups") && typeof settings.hiddenGroups === "array" ?
-            settings.hiddenGroups : [];
+class Prompt {
+    constructor(settings) {
+        this.hiddenGroups =
+            typeof settings === "object" && settings.hasOwnProperty("hiddenGroups") && typeof settings.hiddenGroups === "array" ?
+                settings.hiddenGroups : [];
 
-    this._DEFAULTGROUPCOLORS = {
-        "INFO": "FGBLUE",
-        "SUCCESS": "FGGREEN",
-        "ERROR": "FGRED",
-        "DEBUG": "FGCYAN",
-        "WARNING": "FGYELLOW"
+        this._DEFAULTGROUPCOLORS = {
+            "INFO": "FGBLUE",
+            "SUCCESS": "FGGREEN",
+            "ERROR": "FGRED",
+            "DEBUG": "FGCYAN",
+            "WARNING": "FGYELLOW"
+        }
+
+        this.groupColors = typeof settings === "object" && settings.hasOwnProperty("groupColors") && typeof settings.groupColors === "object" ?
+            settings.groupColors : {};
+
+        this.showTime = typeof settings === "object" && settings.hasOwnProperty("showTime") && typeof settings.showTime === "boolean" ?
+            settings.showTime : true;
+
+        this.colors = true;
     }
 
-    this.groupColors = typeof settings === "object" && settings.hasOwnProperty("groupColors") && typeof settings.groupColors === "object" ?
-        settings.groupColors : {};
+    /**
+     * Inits the singleton
+     * @param {Object} [settings]
+     * @return {Prompt} The instance.
+     */
+    static init(settings) {
+        if (instance === null)
+            instance = new Prompt(settings);
+        return instance;
+    }
 
-    this.showTime = typeof settings === "object" && settings.hasOwnProperty("showTime") && typeof settings.showTime === "boolean" ?
-        settings.showTime : true;
+    /**
+     * Saves the settings, to export them to a new instance (e.g. hot-reload)
+     * The new Prompt instance can be reconstructed with `Prompt.init(oldInstance.backup());`
+     * @return {Object}
+     */
+    backup() {
+        return {
+            "hiddenGroups": this.hiddenGroups,
+            "groupColors": this.groupColors,
+            "showTime": this.showTime
+        }
+    }
 
-    this.colors = true;
-}
+    /**
+     * Logs something
+     * @param {String} [group] Optional. The group of the log.
+     * @param {String} text The text to show.
+     * @param {String} [groupColor] Group's color. Corresponding to a value in Prompt.COLORS (key)
+     * @param {String} [textColor] Text's color. Corresponding to a value in Prompt.COLORS (key)
+     */
+    log() {
+        if (!this.colors)
+            Prompt.COLORS = {"RESET":"","BRIGHT":"","DIM":"","UNDERSCORE":"","BLINK":"","REVERSE":"","HIDDEN":"","FGBLACK":"","FGRED":"","FGGREEN":"","FGYELLOW":"","FGBLUE":"","FGMAGENTA":"","FGCYAN":"","FGWHITE":"","BGBLACK":"","BGRED":"","BGGREEN":"","BGYELLOW":"","BGBLUE":"","BGMAGENTA":"","BGCYAN":"","BGWHITE":""};
+        else
+            Prompt.COLORS = DEFAULT_COLORS;
 
-/**
- * Saves the settings, to export them to a new instance (e.g. hot-reload)
- * The new Prompt instance can be reconstructed with `Prompt.init(oldInstance.backup());`
- * @return {Object}
- */
-Prompt.prototype.backup = function() {
-    return {
-        "hiddenGroups": this.hiddenGroups,
-        "groupColors": this.groupColors,
-        "showTime": this.showTime
+        let args = Array.from(arguments);
+
+        let group, text = "",
+            groupColor = Prompt.COLORS.FGCYAN,
+            textColor = Prompt.COLORS.RESET;
+
+        if (args.length === 1)
+            text = (args[0]).toString();
+        else {
+            group = args[0].toUpperCase();
+            text = (args[1]).toString();
+            groupColor = args.length >= 3 && typeof args[2] === "string" ? args[2] : groupColor;
+            textColor = args.length >= 4 && typeof args[3] === "string" ? args[3] : textColor;
+        }
+
+        if (this.isGroupHidden(group))
+            return;
+
+        if (typeof group === "string")
+            group = this._centerGroup(group);
+        else
+            group = null;
+
+        readline.cursorTo(process.stdout, 0);
+        readline.clearLine(process.stdout, 0)
+
+        console.log(
+            (this.showTime ? Prompt.COLORS.RESET + "[" + this._getTime() + "] " : "") +
+            (typeof group === "string" ? "[" + groupColor + group + Prompt.COLORS.RESET + "]" : "" + Prompt.COLORS.RESET) + " " +
+            textColor + text + Prompt.COLORS.RESET
+        )
+    }
+
+    /**
+     * Logs a success.
+     * Use only this method to log successes.
+     * @param {String} text
+     * @param {String} [textColor]
+     */
+    success(text, textColor) {
+        return this.log("success", text, this._getDefaultGroupColor("success"), textColor);
+    }
+
+    /**
+     * Logs a warning.
+     * @param {String} text
+     * @param {String} [textColor]
+     */
+    warning(text, textColor) {
+        return this.log("warning", text, this._getDefaultGroupColor("warning"), textColor);
+    }
+
+    /**
+     * Logs a warning.
+     * @param {String} text
+     * @param {String} [textColor]
+     * @alias {@link prompt.warning}
+     */
+    warn() {
+        this.warning.apply(this, Array.from(arguments));
+    }
+
+    /**
+     * Logs an error.
+     * @param {String?} text
+     * @param {(Error|String)?} error
+     * @param {String} [textColor]
+     */
+    error(text, error, textColor) {
+        if (error instanceof Error) {
+            text += " : ";
+
+            if (error.code)
+                text += error.code + "-";
+            if (error.stack)
+                text += error.stack
+            if (error.message)
+                text += "\n" + error.message;
+        } else if (typeof error !== "undefined")
+            text += " : " + error
+
+        if (typeof textColor !== "string")
+            textColor = this._getDefaultGroupColor("error");
+
+        return this.log("error", text, this._getDefaultGroupColor("error"), textColor);
+    }
+
+    /**
+     * Logs an info
+     * @param {String} text
+     */
+    info(text) {
+        return this.log("info", text, this._getDefaultGroupColor("info"));
+    }
+
+    /**
+     * Logs debugging messages.
+     * @param {any} anything
+     */
+    debug(anything) {
+        return this.log("debug", anything, this._getDefaultGroupColor("debug"))
+    }
+
+    /**
+     * Hides a group.
+     * @param {String} group
+     */
+    hideGroup(group) {
+        group = group.toUpperCase();
+
+        if (!this.hiddenGroups.includes(group))
+            this.hiddenGroups.push(group);
+    }
+
+    /**
+     * Removes a group from hidden groups.
+     * @param {String} group
+     */
+    showGroup(group) {
+        group = group.toUpperCase();
+
+        let ind = this.hiddenGroups.indexOf(group);
+
+        if (ind > -1)
+            this.hiddenGroups.splice(ind, 1);
+    }
+
+    /**
+     * Returns wether a group is hidden or not.
+     * @param {String} group
+     * @returns {boolean}
+     */
+    isGroupHidden(group) {
+        return this.hiddenGroups.includes(group.toUpperCase());
+    }
+
+    /**
+     * Returns the default color for a group
+     * @param {String} group
+     * @private
+     * @returns {String} The color.
+     */
+    _getDefaultGroupColor(group) {
+        group = group.toUpperCase();
+
+        if (this.groupColors.hasOwnProperty(group))
+            return this.groupColors[group];
+
+        return Prompt.COLORS[this._DEFAULTGROUPCOLORS[group]] || Prompt.COLORS.RESET;
+    }
+
+    /**
+     * Sets the color of a group.
+     * @param {String} group
+     * @param {String} color The key of a color.
+     */
+    setGroupColor(group, color) {
+        this.groupColors[group.toUpperCase()] = Prompt.COLORS[color.toUpperCase()];
+    }
+
+    /**
+     * Centers a group (as a string)
+     * @private
+     * @param {String} group
+     */
+    _centerGroup(group) {
+        let grplen = group.length,
+            side = (GROUPWIDTH - grplen) / 2;
+
+        let sidestr = " ".repeat(side);
+
+        return (side % 1 != 0 ? sidestr : " ".repeat(side - 1)) + group + sidestr;
+    }
+
+    /**
+     * Returns time in a nice formated way!
+     * @private
+     * @return {String}
+     */
+    _getTime() {
+        let now = new Date(Date.now());
+
+        return ("00" + now.getHours()).slice(-2) + ":" + ("00" + now.getMinutes()).slice(-2) + ":" + ("00" + now.getSeconds()).slice(-2);
+    }
+
+    /**
+     * Shows a nice CLI help.
+     * @param {array[]} args The arguments.
+     */
+    showHelp(args) {
+        console.log(`
+        ${Prompt.COLORS.FGGREEN}Yuno Gasai 2${Prompt.COLORS.RESET} - ${Prompt.COLORS.FGCYAN}Help${Prompt.COLORS.RESET}
+    `);
+
+        args.forEach(element => {
+            console.log("      " + element.argument + " - " + element.description)
+            if (element.aliases)
+                element.aliases.forEach(alias => {
+                    console.log("        aka " + alias)
+                });
+            console.log("");
+        });
+    }
+
+    /**
+     * Write text without jumping a line (writing over the last line)
+     * @param {String} text
+     */
+    writeWithoutJumpingLine(text) {
+        readline.cursorTo(process.stdout, 0);
+        readline.clearLine(process.stdout, 0)
+        process.stdout.write(text);
+    }
+
+    /**
+     * Loads configuration into Prompt.
+     * @param {Yuno} Yuno The instance of Yuno.
+     * @param {Config} config The Yuno's config.
+     */
+    configLoaded(Yuno, config) {
+        let data = {
+            "hiddenGroups": config.get("logging.hidden-groups"),
+            "showTime": Yuno.config.get("logging.show-time"),
+            "groupColors": Yuno.config.get("logging.group-colors")
+        }
+
+        this.hiddenGroups =  typeof data === "object" && data.hasOwnProperty("hiddenGroups") && typeof data.hiddenGroups === "array" ?
+            data.hiddenGroups : [];
+
+        this.groupColors = typeof data === "object" && data.hasOwnProperty("groupColors") && typeof data.groupColors === "object" ?
+            data.groupColors : {};
+
+        this.showTime = typeof data === "object" && data.hasOwnProperty("showTime") && typeof data.showTime === "boolean" ?
+            data.showTime : true;
+    }
+
+    /**
+     * Event handler for shutdown.
+     * @param {Yuno} Yuno The instance.
+     */
+    beforeShutdown(Yuno) {
+        Yuno.config.set("logging.hidden-groups", JSON.stringify(this.hiddenGroups));
+        Yuno.config.set("logging.show-time", this.showTime);
+        Yuno.config.set("logging.group-colors", JSON.stringify(this.groupColors));
     }
 }
 
@@ -98,275 +368,5 @@ Prompt.prototype.backup = function() {
  * @prop {String} BGWHITE  Sets the background white.
  */
 Prompt.COLORS = DEFAULT_COLORS = require("./prompt.COLORS.js");
-
-/**
- * Inits the singleton
- * @param {Object} [settings]
- * @return {Prompt} The instance.
- */
-Prompt.init = function(settings) {
-    if (instance === null)
-        instance = new Prompt(settings);
-    return instance;
-}
-
-/**
- * Logs something
- * @param {String} [group] Optional. The group of the log.
- * @param {String} text The text to show.
- * @param {String} [groupColor] Group's color. Corresponding to a value in Prompt.COLORS (key)
- * @param {String} [textColor] Text's color. Corresponding to a value in Prompt.COLORS (key)
- */
-Prompt.prototype.log = function() {
-    if (!this.colors)
-        Prompt.COLORS = {"RESET":"","BRIGHT":"","DIM":"","UNDERSCORE":"","BLINK":"","REVERSE":"","HIDDEN":"","FGBLACK":"","FGRED":"","FGGREEN":"","FGYELLOW":"","FGBLUE":"","FGMAGENTA":"","FGCYAN":"","FGWHITE":"","BGBLACK":"","BGRED":"","BGGREEN":"","BGYELLOW":"","BGBLUE":"","BGMAGENTA":"","BGCYAN":"","BGWHITE":""};
-    else
-        Prompt.COLORS = DEFAULT_COLORS;
-
-    let args = Array.from(arguments);
-
-    let group, text = "",
-        groupColor = Prompt.COLORS.FGCYAN,
-        textColor = Prompt.COLORS.RESET;
-
-    if (args.length === 1)
-        text = (args[0]).toString();
-    else {
-        group = args[0].toUpperCase();
-        text = (args[1]).toString();
-        groupColor = args.length >= 3 && typeof args[2] === "string" ? args[2] : groupColor;
-        textColor = args.length >= 4 && typeof args[3] === "string" ? args[3] : textColor;
-    }
-
-    if (this.isGroupHidden(group))
-        return;
-
-    if (typeof group === "string")
-        group = this._centerGroup(group);
-    else
-        group = null;
-
-    readline.cursorTo(process.stdout, 0);
-    readline.clearLine(process.stdout, 0)
-
-    console.log(
-        (this.showTime ? Prompt.COLORS.RESET + "[" + this._getTime() + "] " : "") +
-        (typeof group === "string" ? "[" + groupColor + group + Prompt.COLORS.RESET + "]" : "" + Prompt.COLORS.RESET) + " " +
-        textColor + text + Prompt.COLORS.RESET
-    )
-}
-
-/**
- * Logs a success.
- * Use only this method to log successes.
- * @param {String} text
- * @param {String} [textColor]
- */
-Prompt.prototype.success = function(text, textColor) {
-    return this.log("success", text, this._getDefaultGroupColor("success"), textColor);
-}
-
-/**
- * Logs a warning.
- * @param {String} text
- * @param {String} [textColor]
- */
-Prompt.prototype.warning = function(text, textColor) {
-    return this.log("warning", text, this._getDefaultGroupColor("warning"), textColor);
-}
-
-/**
- * Logs a warning.
- * @param {String} text
- * @param {String} [textColor]
- * @alias {@link prompt.warning}
- */
-Prompt.prototype.warn = function() {
-    this.warning.apply(this, Array.from(arguments));
-}
-
-/**
- * Logs an error.
- * @param {String?} text
- * @param {(Error|String)?} error
- * @param {String} [textColor]
- */
-Prompt.prototype.error = function(text, error, textColor) {
-    if (error instanceof Error) {
-        text += " : ";
-
-        if (error.code)
-            text += error.code + "-";
-        if (error.stack)
-            text += error.stack
-        if (error.message)
-            text += "\n" + error.message;
-    } else if (typeof error !== "undefined")
-        text += " : " + error
-
-    if (typeof textColor !== "string")
-        textColor = this._getDefaultGroupColor("error");
-
-    return this.log("error", text, this._getDefaultGroupColor("error"), textColor);
-}
-
-/**
- * Logs an info
- * @param {String} text
- */
-Prompt.prototype.info = function(text) {
-    return this.log("info", text, this._getDefaultGroupColor("info"));
-}
-
-/**
- * Logs debugging messages.
- * @param {any} anything
- */
-Prompt.prototype.debug = function(anything) {
-    return this.log("debug", anything, this._getDefaultGroupColor("debug"))
-}
-
-/**
- * Hides a group.
- * @param {String} group
- */
-Prompt.prototype.hideGroup = function(group) {
-    group = group.toUpperCase();
-
-    if (!this.hiddenGroups.includes(group))
-        this.hiddenGroups.push(group);
-}
-
-/**
- * Removes a group from hidden groups.
- * @param {String} group
- */
-Prompt.prototype.showGroup = function(group) {
-    group = group.toUpperCase();
-
-    let ind = this.hiddenGroups.indexOf(group);
-
-    if (ind > -1)
-        this.hiddenGroups.splice(ind, 1);
-}
-
-/**
- * Returns wether a group is hidden or not.
- * @param {String} group
- * @returns {boolean}
- */
-Prompt.prototype.isGroupHidden = function(group) {
-    return this.hiddenGroups.includes(group.toUpperCase());
-}
-
-/**
- * Returns the default color for a group
- * @param {String} group
- * @private
- * @returns {String} The color.
- */
-Prompt.prototype._getDefaultGroupColor = function(group) {
-    group = group.toUpperCase();
-
-    if (this.groupColors.hasOwnProperty(group))
-        return this.groupColors[group];
-
-    return Prompt.COLORS[this._DEFAULTGROUPCOLORS[group]] || Prompt.COLORS.RESET;
-}
-
-/**
- * Sets the color of a group.
- * @param {String} group
- * @param {String} color The key of a color.
- */
-Prompt.prototype.setGroupColor = function(group, color) {
-    this.groupColors[group.toUpperCase()] = Prompt.COLORS[color.toUpperCase()];
-}
-
-/**
- * Centers a group (as a string)
- * @private
- * @param {String} group
- */
-Prompt.prototype._centerGroup = function(group) {
-    let grplen = group.length,
-        side = (GROUPWIDTH - grplen) / 2;
-
-    let sidestr = " ".repeat(side);
-
-    return (side % 1 != 0 ? sidestr : " ".repeat(side - 1)) + group + sidestr;
-}
-
-/**
- * Returns time in a nice formated way!
- * @private
- * @return {String}
- */
-Prompt.prototype._getTime = function() {
-    let now = new Date(Date.now());
-
-    return ("00" + now.getHours()).slice(-2) + ":" + ("00" + now.getMinutes()).slice(-2) + ":" + ("00" + now.getSeconds()).slice(-2);
-}
-
-/**
- * Shows a nice CLI help.
- * @param {array[]} args The arguments.
- */
-Prompt.prototype.showHelp = function(args) {
-    console.log(`
-        ${Prompt.COLORS.FGGREEN}Yuno Gasai 2${Prompt.COLORS.RESET} - ${Prompt.COLORS.FGCYAN}Help${Prompt.COLORS.RESET}
-    `);
-
-    args.forEach(element => {
-        console.log("      " + element.argument + " - " + element.description)
-        if (element.aliases)
-            element.aliases.forEach(alias => {
-                console.log("        aka " + alias)
-            });
-        console.log("");
-    });
-}
-
-/**
- * Write text without jumping a line (writing over the last line)
- * @param {String} text
- */
-Prompt.prototype.writeWithoutJumpingLine = function(text) {
-    readline.cursorTo(process.stdout, 0);
-    readline.clearLine(process.stdout, 0)
-    process.stdout.write(text);
-}
-
-/**
- * Loads configuration into Prompt.
- * @param {Yuno} Yuno The instance of Yuno.
- * @param {Config} config The Yuno's config.
- */
-Promise.prototype.configLoaded = function(Yuno, config) {
-    let data = {
-        "hiddenGroups": config.get("logging.hidden-groups"),
-        "showTime": Yuno.config.get("logging.show-time"),
-        "groupColors": Yuno.config.get("logging.group-colors")
-    }
-
-    this.hiddenGroups =  typeof data === "object" && data.hasOwnProperty("hiddenGroups") && typeof data.hiddenGroups === "array" ?
-        data.hiddenGroups : [];
-
-    this.groupColors = typeof data === "object" && data.hasOwnProperty("groupColors") && typeof data.groupColors === "object" ?
-        data.groupColors : {};
-
-    this.showTime = typeof data === "object" && data.hasOwnProperty("showTime") && typeof data.showTime === "boolean" ?
-        data.showTime : true;
-}
-
-/**
- * Event handler for shutdown.
- * @param {Yuno} Yuno The instance.
- */
-Prompt.prototype.beforeShutdown = function(Yuno) {
-    Yuno.config.set("logging.hidden-groups", JSON.stringify(this.hiddenGroups));
-    Yuno.config.set("logging.show-time", this.showTime);
-    Yuno.config.set("logging.group-colors", JSON.stringify(this.groupColors));
-}
 
 module.exports = Prompt;


### PR DESCRIPTION
## Summary
- Convert all `util.inherits` patterns to ES6 classes extending EventEmitter
- Convert fs callbacks to `fs.promises` with async/await
- Fix multiple bugs in anime.js command (typos, Discord.js v14 API)
- Fix bug in prompt.js (`Promise.prototype.configLoaded` → `Prompt.prototype.configLoaded`)

## Files Changed

### ES6 Class Conversions (7 files)
| File | Change |
|------|--------|
| `src/Yuno.js` | `class Yuno extends EventEmitter` |
| `src/ModuleExporter.js` | `class ModuleExporter extends EventEmitter` |
| `src/lib/commandManager.js` | `class CommandManager extends EventEmitter` |
| `src/lib/configManager.js` | `class ConfigManager` + `class Config extends Map` |
| `src/lib/intervalManager.js` | `class IntervalManager` |
| `src/lib/interactiveTerm.js` | `class InteractiveTerminal extends EventEmitter` |
| `src/lib/prompt.js` | `class Prompt` |

### Async/Await Conversions
- `src/commands/exportbans.js` - async file writes
- `src/commands/importbans.js` - async file reads
- `src/lib/configManager.js` - async `readConfig` and `save`
- `src/lib/commandManager.js` - async `init`

### Bug Fixes in anime.js
- `item_end_date` → `item.end_date`
- `ReactionCollectior` → `ReactionCollector` with proper v14 options
- `pageMsg.React('X')` → `await pageMsg.react('❌')`
- `Rc.ended` → `RC.ended`

## Test plan
- [ ] Verify bot starts without errors
- [ ] Test anime command with reaction collector
- [ ] Test exportbans/importbans commands
- [ ] Verify hot-reload still works
- [ ] Test config loading/saving

🤖 Generated with [Claude Code](https://claude.com/claude-code)