### PR TITLE
Add moderation enhancements: delay command, slash commands, and mod tracking

### DIFF
--- a/src/commands/ban.js
+++ b/src/commands/ban.js
@@ -138,7 +138,18 @@ module.exports.run = async function(yuno, author, args, msg) {
                 deleteMessageSeconds: 86400,
                 reason: reason
             });
-            
+
+            // Record to database for mod-stats
+            await yuno.dbCommands.addModAction(
+                yuno.database,
+                msg.guild.id,
+                msg.author.id,
+                target.id,
+                "ban",
+                reason,
+                Date.now()
+            );
+
             msg.channel.send({embeds: [successfulEmbed]});
         } catch (err) {
             msg.channel.send({embeds: [new EmbedCmdResponse()

--- a/src/commands/delay.js
+++ b/src/commands/delay.js
@@ -1,0 +1,107 @@
+/*
+    Yuno Gasai. A Discord.JS based bot, with multiple features.
+    Copyright (C) 2018 Maeeen <maeeennn@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see https://www.gnu.org/licenses/.
+*/
+
+const { EmbedBuilder } = require("discord.js");
+
+// Track delay usage per guild/channel: { "guildId-channelName": { count: 0, resetTime: timestamp } }
+const delayUsage = new Map();
+
+// Default configuration
+const DEFAULT_DELAY_MINUTES = 5;
+const MAX_DELAYS = 3;
+
+module.exports.run = async function(yuno, author, args, msg) {
+    const channel = msg.channel;
+    const guildId = msg.guild.id;
+    const channelName = channel.name.toLowerCase();
+
+    // Check if this channel has an auto-clean set up
+    const clean = await yuno.dbCommands.getClean(yuno.database, guildId, channelName);
+
+    if (clean === null) {
+        return msg.channel.send(":negative_squared_cross_mark: This channel doesn't have auto-clean set up.");
+    }
+
+    // Get guild-specific settings or use defaults
+    const guildSettings = await yuno.dbCommands.getGuild(yuno.database, guildId);
+    const delayMinutes = guildSettings?.delayMinutes || DEFAULT_DELAY_MINUTES;
+    const maxDelays = guildSettings?.maxDelays || MAX_DELAYS;
+
+    // Create unique key for this guild/channel combo
+    const usageKey = `${guildId}-${channelName}`;
+
+    // Get or initialize usage tracking for this channel
+    let usage = delayUsage.get(usageKey);
+
+    // Reset usage if the clean cycle has reset (remainingTime is back to full)
+    if (!usage || clean.remainingTime >= clean.timeFEachClean * 60 - 1) {
+        usage = { count: 0, cycleStart: Date.now() };
+        delayUsage.set(usageKey, usage);
+    }
+
+    // Check if max delays reached
+    if (usage.count >= maxDelays) {
+        const embed = new EmbedBuilder()
+            .setColor("#ff0000")
+            .setTitle("Delay Limit Reached")
+            .setDescription(`This channel has already been delayed ${maxDelays} time(s) this cleaning cycle.\nThe delay limit will reset after the next clean.`);
+        return msg.channel.send({ embeds: [embed] });
+    }
+
+    // Apply the delay
+    const newRemainingTime = clean.remainingTime + delayMinutes;
+    await yuno.dbCommands.setClean(
+        yuno.database,
+        guildId,
+        channelName,
+        clean.timeFEachClean,
+        clean.timeBeforeClean,
+        newRemainingTime
+    );
+
+    // Update usage count
+    usage.count++;
+    delayUsage.set(usageKey, usage);
+
+    const delaysRemaining = maxDelays - usage.count;
+
+    const embed = new EmbedBuilder()
+        .setColor("#ff51ff")
+        .setTitle("Cleaning Delayed")
+        .setDescription(`The auto-clean has been delayed by **${delayMinutes} minutes**.`)
+        .addFields(
+            { name: "New Time Until Clean", value: `${yuno.UTIL.formatDuration(newRemainingTime * 60)}`, inline: true },
+            { name: "Delays Remaining", value: `${delaysRemaining}/${maxDelays}`, inline: true }
+        )
+        .setFooter({ text: delaysRemaining === 0 ? "No more delays available this cycle" : `${delaysRemaining} delay(s) remaining this cycle` });
+
+    return msg.channel.send({ embeds: [embed] });
+}
+
+module.exports.about = {
+    "command": "delay",
+    "description": "Delay the auto-clean for this channel. Can be used when the cleaning warning appears. Default delay is 5 minutes, with a maximum of 3 delays per cleaning cycle.",
+    "usage": "delay",
+    "examples": ["delay"],
+    "discord": true,
+    "terminal": false,
+    "list": true,
+    "listTerminal": false,
+    "aliases": ["wait", "hold"],
+    "requiredPermissions": []
+}

--- a/src/commands/kick.js
+++ b/src/commands/kick.js
@@ -91,6 +91,18 @@ module.exports.run = async function(yuno, author, args, msg) {
 
         try {
             await target.kick(reason);
+
+            // Record to database for mod-stats
+            await yuno.dbCommands.addModAction(
+                yuno.database,
+                msg.guild.id,
+                msg.author.id,
+                target.id,
+                "kick",
+                reason,
+                Date.now()
+            );
+
             await msg.channel.send({embeds: [new EmbedCmdResponse()
                 .setColor(SUCCESS_COLOR)
                 .setTitle(":white_check_mark: Kick successful.")

--- a/src/commands/mod-stats.js
+++ b/src/commands/mod-stats.js
@@ -16,18 +16,136 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
-const {GuildMember, EmbedBuilder} = require("discord.js");
+const { EmbedBuilder, PermissionsBitField } = require("discord.js");
 
 module.exports.run = async function(yuno, author, args, msg) {
-    let g = msg.guild,
-        bans = await msg.guild.bans.fetch();
+    const statusMsg = await msg.channel.send(":hourglass: Gathering moderator statistics...");
 
-    // TODO
+    try {
+        const guild = msg.guild;
+
+        // Get basic guild stats
+        const bans = await guild.bans.fetch();
+        const totalBans = bans.size;
+
+        // Get members with mod permissions
+        const members = await guild.members.fetch();
+        const moderators = members.filter(m =>
+            m.permissions.has(PermissionsBitField.Flags.ManageMessages) ||
+            m.permissions.has(PermissionsBitField.Flags.KickMembers) ||
+            m.permissions.has(PermissionsBitField.Flags.BanMembers)
+        );
+
+        // Get database stats
+        const dbStats = await yuno.dbCommands.getModStats(yuno.database, guild.id);
+        const totalTrackedActions = await yuno.dbCommands.getModActionsCount(yuno.database, guild.id);
+
+        // Build action counts object
+        const actionTotals = {};
+        for (const row of dbStats.actionCounts) {
+            actionTotals[row.action] = row.count;
+        }
+
+        // Build per-moderator stats
+        const modStats = {};
+        for (const row of dbStats.modCounts) {
+            if (!modStats[row.moderatorId]) {
+                modStats[row.moderatorId] = { total: 0 };
+            }
+            modStats[row.moderatorId][row.action] = row.count;
+            modStats[row.moderatorId].total += row.count;
+        }
+
+        // Create embed
+        const embed = new EmbedBuilder()
+            .setTitle(`Moderator Statistics for ${guild.name}`)
+            .setColor("#ff69b4")
+            .setThumbnail(guild.iconURL())
+            .setTimestamp();
+
+        // Guild overview
+        embed.addFields({
+            name: "Server Overview",
+            value: [
+                `**Total Members:** ${guild.memberCount}`,
+                `**Total Bans:** ${totalBans}`,
+                `**Moderators:** ${moderators.size}`,
+                `**Tracked Actions:** ${totalTrackedActions}`
+            ].join("\n"),
+            inline: false
+        });
+
+        // Action breakdown
+        if (totalTrackedActions > 0) {
+            embed.addFields({
+                name: "Action Breakdown",
+                value: [
+                    `**Bans:** ${actionTotals.ban || 0}`,
+                    `**Unbans:** ${actionTotals.unban || 0}`,
+                    `**Kicks:** ${actionTotals.kick || 0}`,
+                    `**Timeouts:** ${actionTotals.timeout || 0}`
+                ].join("\n"),
+                inline: true
+            });
+        }
+
+        // Top moderators
+        if (dbStats.topMods.length > 0) {
+            const topModsText = [];
+            for (let i = 0; i < Math.min(5, dbStats.topMods.length); i++) {
+                const mod = dbStats.topMods[i];
+                let modName = mod.moderatorId;
+
+                // Try to get the username
+                try {
+                    const member = await guild.members.fetch(mod.moderatorId).catch(() => null);
+                    if (member) {
+                        modName = member.user.tag;
+                    } else {
+                        const user = await yuno.dC.users.fetch(mod.moderatorId).catch(() => null);
+                        if (user) modName = user.tag;
+                    }
+                } catch (e) {
+                    // Keep the ID if we can't resolve
+                }
+
+                const modData = modStats[mod.moderatorId] || {};
+                const breakdown = [];
+                if (modData.ban) breakdown.push(`${modData.ban} bans`);
+                if (modData.kick) breakdown.push(`${modData.kick} kicks`);
+                if (modData.timeout) breakdown.push(`${modData.timeout} timeouts`);
+                if (modData.unban) breakdown.push(`${modData.unban} unbans`);
+
+                topModsText.push(`**${i + 1}. ${modName}** - ${mod.count} actions\n   ${breakdown.join(", ") || "No details"}`);
+            }
+
+            embed.addFields({
+                name: "Top Moderators",
+                value: topModsText.join("\n\n") || "No data available",
+                inline: false
+            });
+        } else {
+            embed.addFields({
+                name: "No Tracked Actions",
+                value: "Run `.scan-bans` to import moderation history from audit logs.",
+                inline: false
+            });
+        }
+
+        // Footer with help
+        embed.setFooter({ text: "Use .scan-bans to import audit log history" });
+
+        await statusMsg.edit({ content: null, embeds: [embed] });
+
+    } catch (e) {
+        console.error("mod-stats error:", e);
+        await statusMsg.edit(`:x: Error gathering stats: ${e.message}`);
+    }
 }
 
 module.exports.about = {
     "command": "mod-stats",
-    "description": "Give some stats about moderators.",
+    "description": "Show moderator statistics including bans, kicks, and timeouts.",
     "examples": ["mod-stats"],
     "discord": true,
     "terminal": false,

--- a/src/commands/mod-stats.js
+++ b/src/commands/mod-stats.js
@@ -20,7 +20,7 @@ const {GuildMember, EmbedBuilder} = require("discord.js");
 
 module.exports.run = async function(yuno, author, args, msg) {
     let g = msg.guild,
-        bans = await msg.guild.fetchBans();
+        bans = await msg.guild.bans.fetch();
 
     // TODO
 }
@@ -33,6 +33,6 @@ module.exports.about = {
     "terminal": false,
     "list": true,
     "listTerminal": false,
-    "requiredPermissions": ["MANAGE_ROLES"],
+    "requiredPermissions": ["ManageRoles"],
     "aliases": "ms"
 }

--- a/src/commands/scan-bans.js
+++ b/src/commands/scan-bans.js
@@ -1,0 +1,419 @@
+/*
+    Yuno Gasai. A Discord.JS based bot, with multiple features.
+    Copyright (C) 2018 Maeeen <maeeennn@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see https://www.gnu.org/licenses/.
+*/
+
+const { EmbedBuilder, AuditLogEvent } = require("discord.js");
+
+module.exports.run = async function(yuno, author, args, msg) {
+    const mode = args[0]?.toLowerCase();
+
+    if (mode === "audit" || mode === "auditlog") {
+        return scanAuditLogs(yuno, msg);
+    } else if (mode === "bans" || mode === "banlist" || !mode) {
+        return scanBanList(yuno, msg);
+    } else {
+        return msg.channel.send("Usage: `.scan-bans [bans|audit]`\n- `bans` (default): Import all bans from the ban list\n- `audit`: Import from audit logs (includes who banned, but limited history)");
+    }
+}
+
+async function scanBanList(yuno, msg) {
+    const statusMsg = await msg.channel.send(":hourglass: Scanning ban list... This may take a while for large servers.");
+
+    try {
+        let totalImported = 0;
+        let totalSkipped = 0;
+        let totalProcessed = 0;
+        let lastBanId = null;
+        const batchSize = 1000;
+
+        // First, try to build a map of bans from audit logs (for moderator info)
+        await statusMsg.edit(":hourglass: Building audit log cache for moderator info...");
+        const auditBanMap = new Map(); // targetId -> { moderatorId, reason, timestamp }
+
+        try {
+            let hasMoreAudit = true;
+            let lastAuditId = null;
+
+            while (hasMoreAudit) {
+                const fetchOptions = { type: AuditLogEvent.MemberBanAdd, limit: 100 };
+                if (lastAuditId) fetchOptions.before = lastAuditId;
+
+                const auditLogs = await msg.guild.fetchAuditLogs(fetchOptions);
+                const entries = auditLogs.entries;
+
+                if (entries.size === 0) {
+                    hasMoreAudit = false;
+                    break;
+                }
+
+                for (const [id, entry] of entries) {
+                    lastAuditId = id;
+                    if (entry.target?.id) {
+                        auditBanMap.set(entry.target.id, {
+                            moderatorId: entry.executor?.id || "unknown",
+                            reason: entry.reason,
+                            timestamp: entry.createdTimestamp
+                        });
+                    }
+                }
+
+                if (entries.size < 100) hasMoreAudit = false;
+            }
+        } catch (e) {
+            // Audit log access might fail, continue without it
+            console.log("Could not fetch audit logs:", e.message);
+        }
+
+        await statusMsg.edit(`:hourglass: Found ${auditBanMap.size} bans in audit logs. Now scanning full ban list...`);
+
+        // Now fetch all bans with pagination
+        while (true) {
+            const fetchOptions = { limit: batchSize };
+            if (lastBanId) {
+                fetchOptions.after = lastBanId;
+            }
+
+            const bans = await msg.guild.bans.fetch(fetchOptions);
+
+            if (bans.size === 0) {
+                break;
+            }
+
+            for (const [userId, ban] of bans) {
+                lastBanId = userId;
+                totalProcessed++;
+
+                // Check if we already have this ban in the database
+                // Use a simple check - if ANY ban exists for this target in this guild
+                const existingBans = await yuno.database.allPromise(
+                    "SELECT id FROM modActions WHERE gid = ? AND targetId = ? AND action = 'ban' LIMIT 1",
+                    [msg.guild.id, userId]
+                );
+
+                if (existingBans.length > 0) {
+                    totalSkipped++;
+                    continue;
+                }
+
+                // Get moderator info from audit cache if available
+                const auditInfo = auditBanMap.get(userId);
+                const moderatorId = auditInfo?.moderatorId || "unknown";
+                const reason = auditInfo?.reason || ban.reason || null;
+                const timestamp = auditInfo?.timestamp || Date.now(); // Use current time if unknown
+
+                await yuno.dbCommands.addModAction(
+                    yuno.database,
+                    msg.guild.id,
+                    moderatorId,
+                    userId,
+                    "ban",
+                    reason,
+                    timestamp
+                );
+                totalImported++;
+
+                // Update status every 1000 bans
+                if (totalProcessed % 1000 === 0) {
+                    await statusMsg.edit(`:hourglass: Processing bans... ${totalProcessed} checked | ${totalImported} imported | ${totalSkipped} skipped`);
+                }
+            }
+
+            if (bans.size < batchSize) {
+                break;
+            }
+
+            // Small delay to avoid rate limits
+            await new Promise(resolve => setTimeout(resolve, 100));
+        }
+
+        const unknownMods = totalImported - auditBanMap.size;
+
+        const embed = new EmbedBuilder()
+            .setTitle("Ban List Scan Complete")
+            .setColor("#00ff00")
+            .addFields(
+                { name: "Total Processed", value: totalProcessed.toString(), inline: true },
+                { name: "Imported", value: totalImported.toString(), inline: true },
+                { name: "Skipped (existing)", value: totalSkipped.toString(), inline: true },
+                { name: "With Moderator Info", value: Math.min(totalImported, auditBanMap.size).toString(), inline: true },
+                { name: "Unknown Moderator", value: Math.max(0, unknownMods).toString(), inline: true }
+            )
+            .setFooter({ text: "Use .mod-stats to view moderator statistics" })
+            .setTimestamp();
+
+        await statusMsg.edit({ content: null, embeds: [embed] });
+
+    } catch (e) {
+        console.error("scan-bans error:", e);
+        await statusMsg.edit(`:x: Error scanning ban list: ${e.message}`);
+    }
+}
+
+async function scanAuditLogs(yuno, msg) {
+    const statusMsg = await msg.channel.send(":hourglass: Scanning audit logs for moderation actions... This may take a while.");
+
+    try {
+        let totalImported = 0;
+        let totalSkipped = 0;
+
+        // Scan for bans
+        await statusMsg.edit(":hourglass: Scanning ban entries from audit log...");
+        let hasMore = true;
+        let lastId = null;
+
+        while (hasMore) {
+            const fetchOptions = { type: AuditLogEvent.MemberBanAdd, limit: 100 };
+            if (lastId) fetchOptions.before = lastId;
+
+            const auditLogs = await msg.guild.fetchAuditLogs(fetchOptions);
+            const entries = auditLogs.entries;
+
+            if (entries.size === 0) {
+                hasMore = false;
+                break;
+            }
+
+            for (const [id, entry] of entries) {
+                lastId = id;
+                const timestamp = entry.createdTimestamp;
+                const moderatorId = entry.executor?.id || "unknown";
+                const targetId = entry.target?.id;
+                const reason = entry.reason;
+
+                if (!targetId) continue;
+
+                const exists = await yuno.dbCommands.modActionExists(
+                    yuno.database,
+                    msg.guild.id,
+                    targetId,
+                    "ban",
+                    timestamp
+                );
+
+                if (exists) {
+                    totalSkipped++;
+                } else {
+                    await yuno.dbCommands.addModAction(
+                        yuno.database,
+                        msg.guild.id,
+                        moderatorId,
+                        targetId,
+                        "ban",
+                        reason,
+                        timestamp
+                    );
+                    totalImported++;
+                }
+            }
+
+            if (entries.size < 100) hasMore = false;
+            await statusMsg.edit(`:hourglass: Scanning bans... Imported: ${totalImported} | Skipped: ${totalSkipped}`);
+        }
+
+        // Scan for kicks
+        hasMore = true;
+        lastId = null;
+        await statusMsg.edit(`:hourglass: Scanning kick entries... Imported: ${totalImported}`);
+
+        while (hasMore) {
+            const fetchOptions = { type: AuditLogEvent.MemberKick, limit: 100 };
+            if (lastId) fetchOptions.before = lastId;
+
+            const auditLogs = await msg.guild.fetchAuditLogs(fetchOptions);
+            const entries = auditLogs.entries;
+
+            if (entries.size === 0) {
+                hasMore = false;
+                break;
+            }
+
+            for (const [id, entry] of entries) {
+                lastId = id;
+                const timestamp = entry.createdTimestamp;
+                const moderatorId = entry.executor?.id || "unknown";
+                const targetId = entry.target?.id;
+                const reason = entry.reason;
+
+                if (!targetId) continue;
+
+                const exists = await yuno.dbCommands.modActionExists(
+                    yuno.database,
+                    msg.guild.id,
+                    targetId,
+                    "kick",
+                    timestamp
+                );
+
+                if (exists) {
+                    totalSkipped++;
+                } else {
+                    await yuno.dbCommands.addModAction(
+                        yuno.database,
+                        msg.guild.id,
+                        moderatorId,
+                        targetId,
+                        "kick",
+                        reason,
+                        timestamp
+                    );
+                    totalImported++;
+                }
+            }
+
+            if (entries.size < 100) hasMore = false;
+        }
+
+        // Scan for unbans
+        hasMore = true;
+        lastId = null;
+        await statusMsg.edit(`:hourglass: Scanning unban entries... Imported: ${totalImported}`);
+
+        while (hasMore) {
+            const fetchOptions = { type: AuditLogEvent.MemberBanRemove, limit: 100 };
+            if (lastId) fetchOptions.before = lastId;
+
+            const auditLogs = await msg.guild.fetchAuditLogs(fetchOptions);
+            const entries = auditLogs.entries;
+
+            if (entries.size === 0) {
+                hasMore = false;
+                break;
+            }
+
+            for (const [id, entry] of entries) {
+                lastId = id;
+                const timestamp = entry.createdTimestamp;
+                const moderatorId = entry.executor?.id || "unknown";
+                const targetId = entry.target?.id;
+                const reason = entry.reason;
+
+                if (!targetId) continue;
+
+                const exists = await yuno.dbCommands.modActionExists(
+                    yuno.database,
+                    msg.guild.id,
+                    targetId,
+                    "unban",
+                    timestamp
+                );
+
+                if (exists) {
+                    totalSkipped++;
+                } else {
+                    await yuno.dbCommands.addModAction(
+                        yuno.database,
+                        msg.guild.id,
+                        moderatorId,
+                        targetId,
+                        "unban",
+                        reason,
+                        timestamp
+                    );
+                    totalImported++;
+                }
+            }
+
+            if (entries.size < 100) hasMore = false;
+        }
+
+        // Scan for timeouts
+        hasMore = true;
+        lastId = null;
+        await statusMsg.edit(`:hourglass: Scanning timeout entries... Imported: ${totalImported}`);
+
+        while (hasMore) {
+            const fetchOptions = { type: AuditLogEvent.MemberUpdate, limit: 100 };
+            if (lastId) fetchOptions.before = lastId;
+
+            const auditLogs = await msg.guild.fetchAuditLogs(fetchOptions);
+            const entries = auditLogs.entries;
+
+            if (entries.size === 0) {
+                hasMore = false;
+                break;
+            }
+
+            for (const [id, entry] of entries) {
+                lastId = id;
+
+                const timeoutChange = entry.changes?.find(c => c.key === "communication_disabled_until");
+                if (!timeoutChange || !timeoutChange.new) continue;
+
+                const timestamp = entry.createdTimestamp;
+                const moderatorId = entry.executor?.id || "unknown";
+                const targetId = entry.target?.id;
+                const reason = entry.reason;
+
+                if (!targetId) continue;
+
+                const exists = await yuno.dbCommands.modActionExists(
+                    yuno.database,
+                    msg.guild.id,
+                    targetId,
+                    "timeout",
+                    timestamp
+                );
+
+                if (exists) {
+                    totalSkipped++;
+                } else {
+                    await yuno.dbCommands.addModAction(
+                        yuno.database,
+                        msg.guild.id,
+                        moderatorId,
+                        targetId,
+                        "timeout",
+                        reason,
+                        timestamp
+                    );
+                    totalImported++;
+                }
+            }
+
+            if (entries.size < 100) hasMore = false;
+        }
+
+        const embed = new EmbedBuilder()
+            .setTitle("Audit Log Scan Complete")
+            .setColor("#00ff00")
+            .addFields(
+                { name: "Imported", value: totalImported.toString(), inline: true },
+                { name: "Skipped (duplicates)", value: totalSkipped.toString(), inline: true }
+            )
+            .setFooter({ text: "Note: Audit logs only go back ~45 days. Use .scan-bans bans for full ban list." })
+            .setTimestamp();
+
+        await statusMsg.edit({ content: null, embeds: [embed] });
+
+    } catch (e) {
+        console.error("scan-bans audit error:", e);
+        await statusMsg.edit(`:x: Error scanning audit logs: ${e.message}`);
+    }
+}
+
+module.exports.about = {
+    "command": "scan-bans",
+    "description": "Import moderation actions into the database.\n- `.scan-bans` or `.scan-bans bans` - Import all bans from ban list (200K+ supported)\n- `.scan-bans audit` - Import from audit logs (includes who banned, ~45 day history)",
+    "examples": ["scan-bans", "scan-bans bans", "scan-bans audit"],
+    "discord": true,
+    "terminal": false,
+    "list": true,
+    "listTerminal": false,
+    "requiredPermissions": ["BanMembers", "ViewAuditLog"],
+    "aliases": ["scanbans", "import-mod-actions"],
+    "onlyMasterUsers": true
+}

--- a/src/commands/timeout.js
+++ b/src/commands/timeout.js
@@ -1,0 +1,107 @@
+/*
+    Yuno Gasai. A Discord.JS based bot, with multiple features.
+    Copyright (C) 2018 Maeeen <maeeennn@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see https://www.gnu.org/licenses/.
+*/
+
+const { EmbedBuilder } = require("discord.js");
+
+module.exports.run = async function(yuno, author, args, msg) {
+    if (args.length < 2) {
+        return msg.channel.send(":negative_squared_cross_mark: Usage: `.timeout @user <duration in minutes> [reason]`");
+    }
+
+    const target = msg.mentions.users.first();
+    if (!target) {
+        return msg.channel.send(":negative_squared_cross_mark: Please mention a user to timeout.");
+    }
+
+    const duration = parseInt(args[1]);
+    if (isNaN(duration) || duration < 1) {
+        return msg.channel.send(":negative_squared_cross_mark: Please provide a valid duration in minutes (minimum 1).");
+    }
+
+    // Maximum timeout is 28 days (40320 minutes)
+    if (duration > 40320) {
+        return msg.channel.send(":negative_squared_cross_mark: Maximum timeout duration is 28 days (40320 minutes).");
+    }
+
+    const reason = args.slice(2).join(" ") || "No reason provided";
+
+    try {
+        const member = await msg.guild.members.fetch(target.id);
+
+        if (!member) {
+            return msg.channel.send(":negative_squared_cross_mark: User is not in this server.");
+        }
+
+        // Check if target is higher in hierarchy
+        if (member.roles.highest.position >= msg.member.roles.highest.position && msg.guild.ownerId !== msg.author.id) {
+            return msg.channel.send(":negative_squared_cross_mark: You cannot timeout this user as they have equal or higher roles.");
+        }
+
+        // Check if bot can timeout this user
+        const botMember = await msg.guild.members.fetch(msg.client.user.id);
+        if (member.roles.highest.position >= botMember.roles.highest.position) {
+            return msg.channel.send(":negative_squared_cross_mark: I cannot timeout this user as they have equal or higher roles than me.");
+        }
+
+        // Apply the timeout
+        const timeoutMs = duration * 60 * 1000;
+        await member.timeout(timeoutMs, `${reason} (by ${msg.author.tag})`);
+
+        // Record to database
+        await yuno.dbCommands.addModAction(
+            yuno.database,
+            msg.guild.id,
+            msg.author.id,
+            target.id,
+            "timeout",
+            reason,
+            Date.now()
+        );
+
+        const embed = new EmbedBuilder()
+            .setColor("#ff9900")
+            .setTitle("User Timed Out")
+            .setThumbnail(target.displayAvatarURL())
+            .addFields(
+                { name: "User", value: `${target.tag} (${target.id})`, inline: true },
+                { name: "Duration", value: `${duration} minute(s)`, inline: true },
+                { name: "Moderator", value: msg.author.tag, inline: true },
+                { name: "Reason", value: reason }
+            )
+            .setTimestamp();
+
+        return msg.channel.send({ embeds: [embed] });
+
+    } catch (e) {
+        console.error("Timeout error:", e);
+        return msg.channel.send(`:x: Error timing out user: ${e.message}`);
+    }
+}
+
+module.exports.about = {
+    "command": "timeout",
+    "description": "Timeout a user for a specified duration.",
+    "usage": "timeout @user <duration in minutes> [reason]",
+    "examples": ["timeout @user 10 Spamming", "timeout @user 60"],
+    "discord": true,
+    "terminal": false,
+    "list": true,
+    "listTerminal": false,
+    "requiredPermissions": ["ModerateMembers"],
+    "aliases": ["mute", "to"]
+}

--- a/src/commands/unban.js
+++ b/src/commands/unban.js
@@ -50,6 +50,18 @@ module.exports.run = async function(yuno, author, args, msg) {
 
         try {
             await msg.guild.members.unban(e, reason);
+
+            // Record to database for mod-stats
+            await yuno.dbCommands.addModAction(
+                yuno.database,
+                msg.guild.id,
+                msg.author.id,
+                e,
+                "unban",
+                reason,
+                Date.now()
+            );
+
             await msg.channel.send({embeds: [new EmbedCmdResponse()
                 .setColor(SUCCESS_COLOR)
                 .setTitle(":white_check_mark: Unban successful.")

--- a/src/lib/commandManager.js
+++ b/src/lib/commandManager.js
@@ -19,7 +19,8 @@
 const EventEmitter = require("events"),
     fsPromises = require("fs").promises,
     path = require("path"),
-    { GuildMember, PermissionsBitField } = require("discord.js");
+    { GuildMember, PermissionsBitField } = require("discord.js"),
+    prompt = require("./prompt").init();
 
 let insufficientPermissionsMessage = "Insufficient permissions.",
     masterusers = [];

--- a/src/modules/command-executor.js
+++ b/src/modules/command-executor.js
@@ -41,7 +41,7 @@ let msgEvent = (function(msg) {
         else
             return msg.reply((dmMessage !== null ? dmMessage : "I'm just a bot :'(. I can't answer to you.") + "\nYou can also send !source(s) to get the sources of the bot.");
     }
-    
+
     if (typeof workOnlyOnGuild !== "undefined" && workOnlyOnGuild !== null && workOnlyOnGuild.id !== msg.guild.id)
         return;
 
@@ -51,6 +51,21 @@ let msgEvent = (function(msg) {
     // switching to default prefix if guild
     if (guildPrefix === null || typeof guildPrefix === "undefined")
         guildPrefix = defaultPrefix;
+
+    // Check if the bot is mentioned - trigger delay command
+    if (msg.mentions.has(discClient.user) && !msg.mentions.everyone) {
+        // Remove the mention and check if there's a command after it
+        const mentionRegex = new RegExp(`<@!?${discClient.user.id}>`, 'g');
+        const contentWithoutMention = msgCnt.replace(mentionRegex, '').trim();
+
+        // If just a mention or mention with "delay"/"wait"/"hold", run delay command
+        if (contentWithoutMention === '' ||
+            contentWithoutMention.toLowerCase() === 'delay' ||
+            contentWithoutMention.toLowerCase() === 'wait' ||
+            contentWithoutMention.toLowerCase() === 'hold') {
+            return Yuno.commandMan.execute(Yuno, msg.member, 'delay', msg);
+        }
+    }
 
     if (msgCnt.indexOf(guildPrefix) === 0) {
         let command = msgCnt.substring(guildPrefix.length);

--- a/src/modules/slash-commands.js
+++ b/src/modules/slash-commands.js
@@ -1,0 +1,375 @@
+/*
+    Yuno Gasai. A Discord.JS based bot, with multiple features.
+    Copyright (C) 2018 Maeeen <maeeennn@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see https://www.gnu.org/licenses/.
+*/
+
+const { SlashCommandBuilder, REST, Routes, PermissionFlagsBits } = require("discord.js");
+
+let Yuno = null;
+let discClient = null;
+let ONE_TIME_EVENT = false;
+let slashCommandsEnabled = true;
+
+module.exports.modulename = "slash-commands";
+
+// Define slash commands
+const slashCommands = [
+    new SlashCommandBuilder()
+        .setName("delay")
+        .setDescription("Delay the auto-clean for this channel"),
+
+    new SlashCommandBuilder()
+        .setName("clean")
+        .setDescription("Clean a channel")
+        .addChannelOption(option =>
+            option.setName("channel")
+                .setDescription("The channel to clean (defaults to current channel)")
+                .setRequired(false)),
+
+    new SlashCommandBuilder()
+        .setName("ban")
+        .setDescription("Ban a user from the server")
+        .addUserOption(option =>
+            option.setName("user")
+                .setDescription("The user to ban")
+                .setRequired(true))
+        .addStringOption(option =>
+            option.setName("reason")
+                .setDescription("Reason for the ban")
+                .setRequired(false))
+        .setDefaultMemberPermissions(PermissionFlagsBits.BanMembers),
+
+    new SlashCommandBuilder()
+        .setName("kick")
+        .setDescription("Kick a user from the server")
+        .addUserOption(option =>
+            option.setName("user")
+                .setDescription("The user to kick")
+                .setRequired(true))
+        .addStringOption(option =>
+            option.setName("reason")
+                .setDescription("Reason for the kick")
+                .setRequired(false))
+        .setDefaultMemberPermissions(PermissionFlagsBits.KickMembers),
+
+    new SlashCommandBuilder()
+        .setName("unban")
+        .setDescription("Unban a user from the server")
+        .addStringOption(option =>
+            option.setName("user")
+                .setDescription("The user ID to unban")
+                .setRequired(true))
+        .addStringOption(option =>
+            option.setName("reason")
+                .setDescription("Reason for the unban")
+                .setRequired(false))
+        .setDefaultMemberPermissions(PermissionFlagsBits.BanMembers),
+
+    new SlashCommandBuilder()
+        .setName("timeout")
+        .setDescription("Timeout a user")
+        .addUserOption(option =>
+            option.setName("user")
+                .setDescription("The user to timeout")
+                .setRequired(true))
+        .addIntegerOption(option =>
+            option.setName("duration")
+                .setDescription("Duration in minutes")
+                .setRequired(true)
+                .setMinValue(1)
+                .setMaxValue(40320)) // Max 28 days
+        .addStringOption(option =>
+            option.setName("reason")
+                .setDescription("Reason for the timeout")
+                .setRequired(false))
+        .setDefaultMemberPermissions(PermissionFlagsBits.ModerateMembers),
+
+    new SlashCommandBuilder()
+        .setName("mod-stats")
+        .setDescription("Show moderator statistics for this server")
+        .setDefaultMemberPermissions(PermissionFlagsBits.ManageRoles),
+
+    new SlashCommandBuilder()
+        .setName("scan-bans")
+        .setDescription("Import moderation actions into the database")
+        .addStringOption(option =>
+            option.setName("mode")
+                .setDescription("Scan mode")
+                .setRequired(false)
+                .addChoices(
+                    { name: "Ban List (recommended for large servers)", value: "bans" },
+                    { name: "Audit Log (includes moderator info, ~45 day history)", value: "audit" }
+                ))
+        .setDefaultMemberPermissions(PermissionFlagsBits.BanMembers),
+
+    new SlashCommandBuilder()
+        .setName("auto-clean")
+        .setDescription("Manage auto-clean settings for channels")
+        .addSubcommand(subcommand =>
+            subcommand
+                .setName("add")
+                .setDescription("Add auto-clean to a channel")
+                .addChannelOption(option =>
+                    option.setName("channel")
+                        .setDescription("The channel to add auto-clean to")
+                        .setRequired(true))
+                .addIntegerOption(option =>
+                    option.setName("hours")
+                        .setDescription("Hours between each clean")
+                        .setRequired(true)
+                        .setMinValue(1))
+                .addIntegerOption(option =>
+                    option.setName("warning")
+                        .setDescription("Minutes before clean to show warning")
+                        .setRequired(true)
+                        .setMinValue(1)))
+        .addSubcommand(subcommand =>
+            subcommand
+                .setName("remove")
+                .setDescription("Remove auto-clean from a channel")
+                .addChannelOption(option =>
+                    option.setName("channel")
+                        .setDescription("The channel to remove auto-clean from")
+                        .setRequired(true)))
+        .addSubcommand(subcommand =>
+            subcommand
+                .setName("list")
+                .setDescription("List all auto-cleans or info about a specific channel")
+                .addChannelOption(option =>
+                    option.setName("channel")
+                        .setDescription("Specific channel to get info about")
+                        .setRequired(false)))
+        .setDefaultMemberPermissions(PermissionFlagsBits.ManageChannels),
+
+    new SlashCommandBuilder()
+        .setName("prefix")
+        .setDescription("Set the bot prefix for this server")
+        .addStringOption(option =>
+            option.setName("prefix")
+                .setDescription("The new prefix to use")
+                .setRequired(true)
+                .setMaxLength(10))
+        .setDefaultMemberPermissions(PermissionFlagsBits.ManageGuild),
+
+    new SlashCommandBuilder()
+        .setName("help")
+        .setDescription("Show available commands")
+        .addStringOption(option =>
+            option.setName("command")
+                .setDescription("Get help for a specific command")
+                .setRequired(false)),
+];
+
+// Register slash commands with Discord
+async function registerSlashCommands() {
+    if (!slashCommandsEnabled) return;
+
+    const rest = new REST({ version: '10' }).setToken(discClient.token);
+
+    try {
+        Yuno.prompt.info("Registering slash commands...");
+
+        await rest.put(
+            Routes.applicationCommands(discClient.user.id),
+            { body: slashCommands.map(cmd => cmd.toJSON()) }
+        );
+
+        Yuno.prompt.success(`Successfully registered ${slashCommands.length} slash command(s).`);
+    } catch (error) {
+        Yuno.prompt.error("Error registering slash commands:", error);
+    }
+}
+
+// Handle slash command interactions
+async function handleInteraction(interaction) {
+    if (!interaction.isChatInputCommand()) return;
+
+    const { commandName } = interaction;
+
+    // Create a fake message object for compatibility with existing commands
+    const fakeMsg = {
+        channel: interaction.channel,
+        guild: interaction.guild,
+        member: interaction.member,
+        author: interaction.user,
+        mentions: {
+            channels: {
+                first: () => interaction.options.getChannel("channel")
+            },
+            users: {
+                first: () => interaction.options.getUser("user")
+            }
+        },
+        content: "",
+        reply: async (content) => interaction.reply(content),
+        deletable: false
+    };
+
+    // Override channel.send to use interaction.reply
+    let hasReplied = false;
+    const originalSend = fakeMsg.channel.send.bind(fakeMsg.channel);
+    fakeMsg.channel.send = async (content) => {
+        if (!hasReplied) {
+            hasReplied = true;
+            return interaction.reply(content);
+        } else {
+            return interaction.followUp(content);
+        }
+    };
+
+    try {
+        switch (commandName) {
+            case "delay":
+                await Yuno.commandMan.execute(Yuno, interaction.member, "delay", fakeMsg);
+                break;
+
+            case "clean": {
+                const channel = interaction.options.getChannel("channel") || interaction.channel;
+                await Yuno.commandMan.execute(Yuno, interaction.member, `clean <#${channel.id}>`, fakeMsg);
+                break;
+            }
+
+            case "ban": {
+                const user = interaction.options.getUser("user");
+                const reason = interaction.options.getString("reason") || "";
+                await Yuno.commandMan.execute(Yuno, interaction.member, `ban <@${user.id}> ${reason}`, fakeMsg);
+                break;
+            }
+
+            case "kick": {
+                const user = interaction.options.getUser("user");
+                const reason = interaction.options.getString("reason") || "";
+                await Yuno.commandMan.execute(Yuno, interaction.member, `kick <@${user.id}> ${reason}`, fakeMsg);
+                break;
+            }
+
+            case "unban": {
+                const userId = interaction.options.getString("user");
+                const reason = interaction.options.getString("reason") || "";
+                await Yuno.commandMan.execute(Yuno, interaction.member, `unban ${userId} ${reason}`, fakeMsg);
+                break;
+            }
+
+            case "timeout": {
+                const user = interaction.options.getUser("user");
+                const duration = interaction.options.getInteger("duration");
+                const reason = interaction.options.getString("reason") || "";
+                await Yuno.commandMan.execute(Yuno, interaction.member, `timeout <@${user.id}> ${duration} ${reason}`, fakeMsg);
+                break;
+            }
+
+            case "mod-stats":
+                await Yuno.commandMan.execute(Yuno, interaction.member, "mod-stats", fakeMsg);
+                break;
+
+            case "scan-bans": {
+                const mode = interaction.options.getString("mode") || "bans";
+                await Yuno.commandMan.execute(Yuno, interaction.member, `scan-bans ${mode}`, fakeMsg);
+                break;
+            }
+
+            case "auto-clean": {
+                const subcommand = interaction.options.getSubcommand();
+                const channel = interaction.options.getChannel("channel");
+
+                switch (subcommand) {
+                    case "add": {
+                        const hours = interaction.options.getInteger("hours");
+                        const warning = interaction.options.getInteger("warning");
+                        await Yuno.commandMan.execute(Yuno, interaction.member, `auto-clean add <#${channel.id}> ${hours} ${warning}`, fakeMsg);
+                        break;
+                    }
+                    case "remove":
+                        await Yuno.commandMan.execute(Yuno, interaction.member, `auto-clean remove <#${channel.id}>`, fakeMsg);
+                        break;
+                    case "list":
+                        if (channel) {
+                            await Yuno.commandMan.execute(Yuno, interaction.member, `auto-clean list <#${channel.id}>`, fakeMsg);
+                        } else {
+                            await Yuno.commandMan.execute(Yuno, interaction.member, "auto-clean list", fakeMsg);
+                        }
+                        break;
+                }
+                break;
+            }
+
+            case "prefix": {
+                const prefix = interaction.options.getString("prefix");
+                await Yuno.commandMan.execute(Yuno, interaction.member, `prefix ${prefix}`, fakeMsg);
+                break;
+            }
+
+            case "help": {
+                const cmd = interaction.options.getString("command");
+                if (cmd) {
+                    await Yuno.commandMan.execute(Yuno, interaction.member, `help ${cmd}`, fakeMsg);
+                } else {
+                    await Yuno.commandMan.execute(Yuno, interaction.member, "help", fakeMsg);
+                }
+                break;
+            }
+
+            default:
+                if (!hasReplied) {
+                    await interaction.reply({ content: "Unknown command.", ephemeral: true });
+                }
+        }
+    } catch (error) {
+        Yuno.prompt.error(`Error handling slash command ${commandName}:`, error);
+        if (!hasReplied) {
+            await interaction.reply({ content: "An error occurred while executing this command.", ephemeral: true });
+        } else {
+            await interaction.followUp({ content: "An error occurred while executing this command.", ephemeral: true });
+        }
+    }
+}
+
+async function discordConnected(yuno) {
+    discClient = yuno.dC;
+    Yuno = yuno;
+
+    if (slashCommandsEnabled) {
+        await registerSlashCommands();
+    }
+
+    if (!ONE_TIME_EVENT) {
+        discClient.on("interactionCreate", handleInteraction);
+    }
+
+    ONE_TIME_EVENT = true;
+}
+
+module.exports.init = function(yuno, hotReloaded) {
+    if (hotReloaded) {
+        discordConnected(yuno);
+    } else {
+        yuno.on("discord-connected", discordConnected);
+    }
+}
+
+module.exports.configLoaded = function(yuno, config) {
+    const enabled = config.get("slash-commands.enabled");
+    if (typeof enabled === "boolean") {
+        slashCommandsEnabled = enabled;
+    }
+}
+
+module.exports.beforeShutdown = function(yuno) {
+    if (discClient) {
+        discClient.removeListener("interactionCreate", handleInteraction);
+    }
+    ONE_TIME_EVENT = false;
+}


### PR DESCRIPTION
## Summary
- Add `.delay` command to extend auto-clean timeout (5 min default, max 3 times per cycle)
- Bot mention now triggers delay command in auto-clean channels
- Add slash command support with commands for: delay, clean, ban, kick, unban, timeout, mod-stats, scan-bans, auto-clean, prefix, help
- Add `.timeout` command for Discord timeout functionality
- Add `.scan-bans` command to import moderation history from ban list/audit logs (supports 200K+ bans)
- Implement `mod-stats` command to show moderator statistics
- Add `modActions` table to database for tracking bans, kicks, timeouts, unbans
- Update ban, kick, unban commands to record actions in database

## New Commands
| Command | Description |
|---------|-------------|
| `.delay` | Delay auto-clean by 5 minutes (max 3x per cycle) |
| `.timeout @user <mins> [reason]` | Timeout a user |
| `.scan-bans [bans\|audit]` | Import moderation history |
| `.mod-stats` | Show moderator statistics |

## Slash Commands
All major commands now have slash command equivalents (`/delay`, `/ban`, `/kick`, etc.)

## Test plan
- [ ] Test `.delay` command in a channel with auto-clean
- [ ] Test bot mention to trigger delay
- [ ] Test slash commands registration on bot startup
- [ ] Test `.timeout` command
- [ ] Test `.scan-bans` with both modes
- [ ] Test `.mod-stats` displays correct statistics

🤖 Generated with [Claude Code](https://claude.com/claude-code)