### PR TITLE
Add activity logging and voice channel XP features

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Yuno is a **yandere-themed Discord bot** combining powerful moderation tools wit
 - 📈 Mass XP commands
 - 🔄 Level role syncing
 - 🏆 Server leaderboards
+- 🎤 Voice channel XP rewards
 
 </td>
 </tr>
@@ -91,6 +92,18 @@ Yuno is a **yandere-themed Discord bot** combining powerful moderation tools wit
 </td>
 </tr>
 <tr>
+<td width="50%">
+
+### 📋 Activity Logging
+*"I see everything that happens here~"*
+- 🎤 Voice channel join/leave/move
+- 📝 Nickname changes
+- 🖼️ Avatar/profile changes
+- 🟢 Presence status tracking
+- ⚡ Smart batching (rate limit safe)
+- ⏱️ Configurable flush intervals
+
+</td>
 <td width="50%">
 
 ### 🔐 Database Security
@@ -251,6 +264,92 @@ Configure database optimizations in `DEFAULT_CONFIG.json` based on your hosting:
 
 ---
 
+## 📋 Activity Logging
+
+*"I see everything... every move, every change~"* 👁️💕
+
+Yuno can log server activity to designated channels with smart batching to respect Discord's rate limits.
+
+### 🎯 What Can Be Logged
+
+| Log Type | Events |
+|----------|--------|
+| `voice` | Voice channel joins, leaves, moves |
+| `nickname` | Member nickname changes |
+| `avatar` | Profile picture changes |
+| `presence` | Online/offline/idle/DND status changes |
+| `unified` | Fallback channel for all log types |
+
+### 🔧 Setup Commands
+
+```bash
+# Set a log channel
+.set-logchannel voice #voice-logs
+.set-logchannel presence #status-logs
+.set-logchannel unified #all-logs
+
+# Remove a log channel
+.set-logchannel voice none
+
+# View current configuration
+.log-status
+```
+
+### ⚡ Batching Configuration
+
+Logs are batched together and sent at intervals to avoid rate limits:
+
+```bash
+# View current settings
+.set-logsettings
+
+# Set flush interval (10-300 seconds)
+.set-logsettings interval 60
+
+# Set max buffer size (10-100 entries)
+.set-logsettings buffer 25
+```
+
+> ⚠️ **Note:** The `PRESENCE INTENT` must be enabled in the Discord Developer Portal for presence logging.
+
+---
+
+## 🎤 Voice Channel XP
+
+*"Spend time with me... and I'll reward you~"* 💕
+
+Users earn XP for time spent in voice channels, integrated with the main leveling system.
+
+### 🔧 Setup Commands
+
+```bash
+# Enable/disable VC XP
+.set-vcxp enable
+.set-vcxp disable
+
+# Set XP amount per interval (default: 10)
+.set-vcxp rate 15
+
+# Set interval in seconds (default: 300 = 5 min)
+.set-vcxp interval 300
+
+# Ignore AFK channel (default: true)
+.set-vcxp ignore-afk true
+
+# View current config and active sessions
+.vcxp-status
+```
+
+### 💡 How It Works
+
+- XP is granted based on time spent in voice channels
+- Uses the same XP/level system as chat XP
+- Level-up roles are automatically assigned
+- AFK channel can be excluded from earning XP
+- Sessions are recovered if the bot restarts
+
+---
+
 ## 💖 Commands Preview
 
 | Command | Description |
@@ -264,6 +363,10 @@ Configure database optimizations in `DEFAULT_CONFIG.json` based on your hosting:
 | `8ball` | *"Let fate decide~"* 🎱 |
 | `neko` | *"Nya~"* 🐱 |
 | `db-encrypt` | *"Your secrets are mine to keep~"* 🔐 |
+| `set-logchannel` | *"I'll watch over everything~"* 📋 |
+| `log-status` | *"Here's what I'm watching~"* 👁️ |
+| `set-vcxp` | *"Time with me is rewarding~"* 🎤 |
+| `vcxp-status` | *"Who's spending time with me?"* 💕 |
 
 *Use the `list` command to see all available commands!*
 

--- a/src/Yuno.js
+++ b/src/Yuno.js
@@ -58,6 +58,9 @@ class Yuno extends EventEmitter {
     constructor() {
         super();
 
+        // Increase max listeners to accommodate all modules
+        this.setMaxListeners(20);
+
         this.prompt = ModuleExporter.singletonPreset(this, "prompt")
 
         // Not hot-reloading this one: it's the core of interactivity => essential.
@@ -85,7 +88,9 @@ class Yuno extends EventEmitter {
                 GatewayIntentBits.GuildMessages,
                 GatewayIntentBits.MessageContent,
                 GatewayIntentBits.DirectMessages,
-                GatewayIntentBits.GuildBans
+                GatewayIntentBits.GuildBans,
+                GatewayIntentBits.GuildVoiceStates,
+                GatewayIntentBits.GuildPresences
             ]
         });
         this.dC = this.discordClient;

--- a/src/commands/log-status.js
+++ b/src/commands/log-status.js
@@ -1,0 +1,82 @@
+/*
+    Yuno Gasai. A Discord.JS based bot, with multiple features.
+    Copyright (C) 2018 Maeeen <maeeennn@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see https://www.gnu.org/licenses/.
+*/
+
+const { EmbedBuilder } = require("discord.js");
+
+const LOG_TYPE_DESCRIPTIONS = {
+    unified: "All logs (fallback)",
+    voice: "Voice channel events",
+    nickname: "Nickname changes",
+    avatar: "Avatar changes",
+    presence: "Presence status changes"
+};
+
+module.exports.run = async function(yuno, author, args, msg) {
+    const logChannels = await yuno.dbCommands.getLogChannels(yuno.database, msg.guild.id);
+    const logSettings = await yuno.dbCommands.getLogSettings(yuno.database, msg.guild.id);
+
+    const embed = new EmbedBuilder()
+        .setTitle("Activity Logging Configuration")
+        .setColor(0x0099ff)
+        .setTimestamp();
+
+    if (Object.keys(logChannels).length === 0) {
+        embed.setDescription("No log channels configured.\n\nUse `set-logchannel <type> <#channel>` to configure logging.");
+    } else {
+        let description = "";
+
+        for (const [logType, config] of Object.entries(logChannels)) {
+            const channel = msg.guild.channels.cache.get(config.channelId);
+            const channelDisplay = channel ? `<#${channel.id}>` : `*Unknown (${config.channelId})*`;
+            const status = config.enabled ? ":white_check_mark:" : ":x:";
+
+            description += `**${logType}** - ${LOG_TYPE_DESCRIPTIONS[logType] || "Unknown"}\n`;
+            description += `${status} Channel: ${channelDisplay}\n\n`;
+        }
+
+        embed.setDescription(description);
+    }
+
+    embed.addFields(
+        {
+            name: "Batching Settings",
+            value: `**Flush Interval:** ${logSettings.flushInterval}s\n**Max Buffer:** ${logSettings.maxBufferSize} entries\n\nUse \`set-logsettings\` to configure`,
+            inline: true
+        },
+        {
+            name: "Available Log Types",
+            value: Object.entries(LOG_TYPE_DESCRIPTIONS)
+                .map(([type, desc]) => `\`${type}\` - ${desc}`)
+                .join("\n")
+        }
+    );
+
+    msg.channel.send({ embeds: [embed] });
+}
+
+module.exports.about = {
+    "command": "log-status",
+    "description": "View current activity logging configuration for this guild.",
+    "usage": "log-status",
+    "examples": ["log-status"],
+    "discord": true,
+    "terminal": false,
+    "list": true,
+    "listTerminal": false,
+    "aliases": ["logstatus", "logs"]
+}

--- a/src/commands/set-logchannel.js
+++ b/src/commands/set-logchannel.js
@@ -1,0 +1,96 @@
+/*
+    Yuno Gasai. A Discord.JS based bot, with multiple features.
+    Copyright (C) 2018 Maeeen <maeeennn@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see https://www.gnu.org/licenses/.
+*/
+
+const VALID_LOG_TYPES = ["unified", "voice", "nickname", "avatar", "presence"];
+
+module.exports.run = async function(yuno, author, args, msg) {
+    if (args.length < 1) {
+        return msg.channel.send(`:negative_squared_cross_mark: Not enough arguments.\nUsage: \`set-logchannel <type> <#channel|none>\`\nValid types: ${VALID_LOG_TYPES.join(", ")}`);
+    }
+
+    const logType = args[0].toLowerCase();
+
+    if (!VALID_LOG_TYPES.includes(logType)) {
+        return msg.channel.send(`:negative_squared_cross_mark: Invalid log type. Valid types: ${VALID_LOG_TYPES.join(", ")}`);
+    }
+
+    // If "none" is specified, remove the log channel
+    if (args[1] && args[1].toLowerCase() === "none") {
+        await yuno.dbCommands.removeLogChannel(yuno.database, msg.guild.id, logType);
+        return msg.channel.send(`:white_check_mark: Removed **${logType}** log channel.`);
+    }
+
+    // Get the channel from mentions or by ID
+    let channel = msg.mentions.channels.first();
+    if (!channel && args[1]) {
+        // Try to parse as channel ID
+        try {
+            channel = await msg.guild.channels.fetch(args[1].replace(/[<#>]/g, ""));
+        } catch(e) {
+            return msg.channel.send(":negative_squared_cross_mark: Invalid channel. Please mention a channel or provide a valid channel ID.");
+        }
+    }
+
+    if (!channel) {
+        return msg.channel.send(":negative_squared_cross_mark: Please specify a channel. Usage: `set-logchannel <type> <#channel|none>`");
+    }
+
+    // Verify it's a text channel
+    if (!channel.isTextBased()) {
+        return msg.channel.send(":negative_squared_cross_mark: The specified channel must be a text channel.");
+    }
+
+    // Check if bot can send messages to the channel
+    const botMember = msg.guild.members.cache.get(msg.client.user.id);
+    if (!channel.permissionsFor(botMember).has("SendMessages")) {
+        return msg.channel.send(":negative_squared_cross_mark: I don't have permission to send messages in that channel.");
+    }
+
+    // Save the log channel
+    await yuno.dbCommands.setLogChannel(yuno.database, msg.guild.id, logType, channel.id);
+
+    const typeDescriptions = {
+        unified: "all log types (fallback)",
+        voice: "voice channel join/leave/move",
+        nickname: "nickname changes",
+        avatar: "avatar changes",
+        presence: "presence status changes (online/offline/idle/dnd)"
+    };
+
+    msg.channel.send(`:white_check_mark: Set **${logType}** log channel to ${channel}.\nThis will log: ${typeDescriptions[logType]}`);
+}
+
+module.exports.about = {
+    "command": "set-logchannel",
+    "description": "Configure logging channels for activity logging (voice, nickname, avatar, presence changes).",
+    "usage": "set-logchannel <type> <#channel|none>",
+    "examples": [
+        "set-logchannel unified #logs",
+        "set-logchannel voice #voice-logs",
+        "set-logchannel nickname #member-logs",
+        "set-logchannel avatar #member-logs",
+        "set-logchannel presence #presence-logs",
+        "set-logchannel voice none"
+    ],
+    "discord": true,
+    "terminal": false,
+    "list": true,
+    "listTerminal": false,
+    "aliases": ["setlog", "slc"],
+    "onlyMasterUsers": true
+}

--- a/src/commands/set-logsettings.js
+++ b/src/commands/set-logsettings.js
@@ -1,0 +1,92 @@
+/*
+    Yuno Gasai. A Discord.JS based bot, with multiple features.
+    Copyright (C) 2018 Maeeen <maeeennn@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see https://www.gnu.org/licenses/.
+*/
+
+module.exports.run = async function(yuno, author, args, msg) {
+    if (args.length < 1) {
+        const settings = await yuno.dbCommands.getLogSettings(yuno.database, msg.guild.id);
+        return msg.channel.send(`**Current Log Settings:**
+• **Flush Interval:** ${settings.flushInterval} seconds
+• **Max Buffer Size:** ${settings.maxBufferSize} entries
+
+**Usage:**
+\`set-logsettings interval <10-300>\` - Seconds between log batches
+\`set-logsettings buffer <10-100>\` - Max entries before force flush
+
+Lower interval = more frequent updates (more API calls)
+Higher interval = more grouped logs (more efficient)`);
+    }
+
+    const subcommand = args[0].toLowerCase();
+    const settings = await yuno.dbCommands.getLogSettings(yuno.database, msg.guild.id);
+
+    switch (subcommand) {
+        case "interval":
+        case "flush":
+            if (args.length < 2) {
+                return msg.channel.send(":negative_squared_cross_mark: Please specify the flush interval in seconds (10-300).");
+            }
+            const interval = parseInt(args[1]);
+            if (isNaN(interval)) {
+                return msg.channel.send(":negative_squared_cross_mark: Please provide a valid number.");
+            }
+            if (interval < 10 || interval > 300) {
+                return msg.channel.send(":negative_squared_cross_mark: Interval must be between **10** and **300** seconds.\n• 10s minimum to respect Discord API rate limits\n• 300s (5 min) maximum for timely logs");
+            }
+            settings.flushInterval = interval;
+            await yuno.dbCommands.setLogSettings(yuno.database, msg.guild.id, settings);
+            return msg.channel.send(`:white_check_mark: Log flush interval set to **${interval} seconds**.`);
+
+        case "buffer":
+        case "max":
+        case "size":
+            if (args.length < 2) {
+                return msg.channel.send(":negative_squared_cross_mark: Please specify the max buffer size (10-100).");
+            }
+            const size = parseInt(args[1]);
+            if (isNaN(size)) {
+                return msg.channel.send(":negative_squared_cross_mark: Please provide a valid number.");
+            }
+            if (size < 10 || size > 100) {
+                return msg.channel.send(":negative_squared_cross_mark: Buffer size must be between **10** and **100** entries.");
+            }
+            settings.maxBufferSize = size;
+            await yuno.dbCommands.setLogSettings(yuno.database, msg.guild.id, settings);
+            return msg.channel.send(`:white_check_mark: Max buffer size set to **${size} entries**.\nLogs will be sent when this many events accumulate (even before the interval).`);
+
+        default:
+            return msg.channel.send(`:negative_squared_cross_mark: Unknown setting: \`${subcommand}\`
+Valid settings: \`interval\`, \`buffer\``);
+    }
+}
+
+module.exports.about = {
+    "command": "set-logsettings",
+    "description": "Configure log batching settings (flush interval and buffer size).",
+    "usage": "set-logsettings [setting] [value]",
+    "examples": [
+        "set-logsettings",
+        "set-logsettings interval 60",
+        "set-logsettings buffer 25"
+    ],
+    "discord": true,
+    "terminal": false,
+    "list": true,
+    "listTerminal": false,
+    "aliases": ["logsettings", "logconfig"],
+    "onlyMasterUsers": true
+}

--- a/src/commands/set-vcxp.js
+++ b/src/commands/set-vcxp.js
@@ -1,0 +1,106 @@
+/*
+    Yuno Gasai. A Discord.JS based bot, with multiple features.
+    Copyright (C) 2018 Maeeen <maeeennn@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see https://www.gnu.org/licenses/.
+*/
+
+module.exports.run = async function(yuno, author, args, msg) {
+    if (args.length < 1) {
+        return msg.channel.send(`:negative_squared_cross_mark: Not enough arguments.
+Usage:
+\`set-vcxp enable\` - Enable VC XP
+\`set-vcxp disable\` - Disable VC XP
+\`set-vcxp rate <xp>\` - Set XP per interval (default: 10)
+\`set-vcxp interval <seconds>\` - Set time interval in seconds (default: 300)
+\`set-vcxp ignore-afk <true|false>\` - Ignore AFK channel (default: true)`);
+    }
+
+    const subcommand = args[0].toLowerCase();
+    const config = await yuno.dbCommands.getVcXpConfig(yuno.database, msg.guild.id);
+
+    switch (subcommand) {
+        case "enable":
+            config.enabled = true;
+            await yuno.dbCommands.setVcXpConfig(yuno.database, msg.guild.id, config);
+            return msg.channel.send(`:white_check_mark: Voice channel XP is now **enabled**.
+Users will earn **${config.xpPerInterval} XP** every **${config.intervalSeconds} seconds** in voice channels.`);
+
+        case "disable":
+            config.enabled = false;
+            await yuno.dbCommands.setVcXpConfig(yuno.database, msg.guild.id, config);
+            return msg.channel.send(":white_check_mark: Voice channel XP is now **disabled**.");
+
+        case "rate":
+            if (args.length < 2) {
+                return msg.channel.send(":negative_squared_cross_mark: Please specify the XP amount. Usage: `set-vcxp rate <xp>`");
+            }
+            const xp = parseInt(args[1]);
+            if (isNaN(xp) || xp < 1 || xp > 1000) {
+                return msg.channel.send(":negative_squared_cross_mark: XP must be a number between 1 and 1000.");
+            }
+            config.xpPerInterval = xp;
+            await yuno.dbCommands.setVcXpConfig(yuno.database, msg.guild.id, config);
+            return msg.channel.send(`:white_check_mark: VC XP rate set to **${xp} XP** per interval.`);
+
+        case "interval":
+            if (args.length < 2) {
+                return msg.channel.send(":negative_squared_cross_mark: Please specify the interval in seconds. Usage: `set-vcxp interval <seconds>`");
+            }
+            const interval = parseInt(args[1]);
+            if (isNaN(interval) || interval < 60 || interval > 3600) {
+                return msg.channel.send(":negative_squared_cross_mark: Interval must be between 60 and 3600 seconds (1 minute to 1 hour).");
+            }
+            config.intervalSeconds = interval;
+            await yuno.dbCommands.setVcXpConfig(yuno.database, msg.guild.id, config);
+            return msg.channel.send(`:white_check_mark: VC XP interval set to **${interval} seconds** (${Math.floor(interval / 60)} minutes).`);
+
+        case "ignore-afk":
+        case "ignoreafk":
+            if (args.length < 2) {
+                return msg.channel.send(":negative_squared_cross_mark: Please specify true or false. Usage: `set-vcxp ignore-afk <true|false>`");
+            }
+            const ignoreAfk = args[1].toLowerCase() === "true" || args[1] === "1" || args[1].toLowerCase() === "yes";
+            config.ignoreAfkChannel = ignoreAfk;
+            await yuno.dbCommands.setVcXpConfig(yuno.database, msg.guild.id, config);
+            if (ignoreAfk) {
+                return msg.channel.send(":white_check_mark: AFK channel will be **ignored** for VC XP.");
+            } else {
+                return msg.channel.send(":white_check_mark: AFK channel will **grant** VC XP.");
+            }
+
+        default:
+            return msg.channel.send(`:negative_squared_cross_mark: Unknown subcommand: \`${subcommand}\`
+Valid subcommands: \`enable\`, \`disable\`, \`rate\`, \`interval\`, \`ignore-afk\``);
+    }
+}
+
+module.exports.about = {
+    "command": "set-vcxp",
+    "description": "Configure voice channel XP settings. VC XP is added to the main XP system.",
+    "usage": "set-vcxp <subcommand> [value]",
+    "examples": [
+        "set-vcxp enable",
+        "set-vcxp disable",
+        "set-vcxp rate 15",
+        "set-vcxp interval 300",
+        "set-vcxp ignore-afk true"
+    ],
+    "discord": true,
+    "terminal": false,
+    "list": true,
+    "listTerminal": false,
+    "aliases": ["vcxp", "voicexp"],
+    "onlyMasterUsers": true
+}

--- a/src/commands/vcxp-status.js
+++ b/src/commands/vcxp-status.js
@@ -1,0 +1,85 @@
+/*
+    Yuno Gasai. A Discord.JS based bot, with multiple features.
+    Copyright (C) 2018 Maeeen <maeeennn@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see https://www.gnu.org/licenses/.
+*/
+
+const { EmbedBuilder } = require("discord.js");
+
+module.exports.run = async function(yuno, author, args, msg) {
+    const config = await yuno.dbCommands.getVcXpConfig(yuno.database, msg.guild.id);
+    const sessions = await yuno.dbCommands.getGuildVcSessions(yuno.database, msg.guild.id);
+
+    const embed = new EmbedBuilder()
+        .setTitle("Voice Channel XP Configuration")
+        .setColor(config.enabled ? 0x00ff00 : 0xff0000)
+        .setTimestamp();
+
+    // Status
+    const statusText = config.enabled ? ":white_check_mark: **Enabled**" : ":x: **Disabled**";
+
+    // Calculate XP per hour
+    const intervalsPerHour = 3600 / config.intervalSeconds;
+    const xpPerHour = Math.floor(intervalsPerHour * config.xpPerInterval);
+
+    embed.addFields(
+        { name: "Status", value: statusText, inline: true },
+        { name: "XP per Interval", value: `${config.xpPerInterval} XP`, inline: true },
+        { name: "Interval", value: `${config.intervalSeconds}s (${Math.floor(config.intervalSeconds / 60)}m)`, inline: true },
+        { name: "XP per Hour", value: `~${xpPerHour} XP/hour`, inline: true },
+        { name: "Ignore AFK Channel", value: config.ignoreAfkChannel ? "Yes" : "No", inline: true },
+        { name: "Active VC Sessions", value: `${sessions.length} users`, inline: true }
+    );
+
+    // Show users currently earning XP
+    if (sessions.length > 0 && sessions.length <= 10) {
+        const now = Date.now();
+        const userList = sessions.map(session => {
+            const member = msg.guild.members.cache.get(session.oderId);
+            const displayName = member ? member.displayName : `User ${session.oderId}`;
+            const timeInVc = Math.floor((now - session.joinedAt) / 60000); // minutes
+            return `• ${displayName} (${timeInVc}m)`;
+        }).join("\n");
+
+        embed.addFields({ name: "Users in Voice", value: userList || "None" });
+    } else if (sessions.length > 10) {
+        embed.addFields({ name: "Users in Voice", value: `${sessions.length} users currently in voice channels` });
+    }
+
+    // AFK channel info
+    if (msg.guild.afkChannelId) {
+        const afkChannel = msg.guild.channels.cache.get(msg.guild.afkChannelId);
+        if (afkChannel) {
+            embed.addFields({
+                name: "AFK Channel",
+                value: `<#${afkChannel.id}> ${config.ignoreAfkChannel ? "(not granting XP)" : "(granting XP)"}`
+            });
+        }
+    }
+
+    msg.channel.send({ embeds: [embed] });
+}
+
+module.exports.about = {
+    "command": "vcxp-status",
+    "description": "View voice channel XP configuration and active sessions.",
+    "usage": "vcxp-status",
+    "examples": ["vcxp-status"],
+    "discord": true,
+    "terminal": false,
+    "list": true,
+    "listTerminal": false,
+    "aliases": ["voicestatus", "vcstatus"]
+}

--- a/src/message-processors/custom-spam-rules/447665600135823361.js
+++ b/src/message-processors/custom-spam-rules/447665600135823361.js
@@ -35,9 +35,9 @@ module.exports.message = async function(content, msg) {
             }
         }
         // Obtain the member for the ClientUser if it doesn't already exist
-        if(msg.guild && !msg.guild.members.cache.has(Yuno.dC.user.id)) {
+        if(msg.guild && !msg.guild.members.cache.has(msg.client.user.id)) {
             try {
-                await msg.guild.members.fetch(Yuno.dC.user.id);
+                await msg.guild.members.fetch(msg.client.user.id);
             } catch(e) {
                 // Bot not in guild cache, skip
             }

--- a/src/message-processors/spamfilter.js
+++ b/src/message-processors/spamfilter.js
@@ -85,8 +85,8 @@ module.exports.message = async function(content, msg) {
         msg.member = await msg.guild.members.fetch(msg.author);
     }
     // Obtain the member for the ClientUser if it doesn't already exist
-    if(msg.guild && !msg.guild.members.cache.has(Yuno.dC.user.id)) {
-        await msg.guild.members.fetch(Yuno.dC.user.id);
+    if(msg.guild && !msg.guild.members.cache.has(msg.client.user.id)) {
+        await msg.guild.members.fetch(msg.client.user.id);
     }
 
 

--- a/src/modules/activity-logger.js
+++ b/src/modules/activity-logger.js
@@ -1,0 +1,548 @@
+/*
+    Yuno Gasai. A Discord.JS based bot, with multiple features.
+    Copyright (C) 2018 Maeeen <maeeennn@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see https://www.gnu.org/licenses/.
+*/
+
+module.exports.modulename = "activity-logger";
+
+const { EmbedBuilder } = require("discord.js");
+
+let DISCORD_EVENTED = false,
+    discClient = null,
+    yunoInstance = null,
+    voiceStateHandler = null,
+    guildMemberUpdateHandler = null,
+    userUpdateHandler = null,
+    presenceUpdateHandler = null,
+    flushInterval = null;
+
+// Buffer for collecting log entries before sending
+// Structure: Map<guildId, Map<logType, Array<logEntry>>>
+const logBuffer = new Map();
+
+// Track rate limit state per channel
+const rateLimitState = new Map();
+
+// Cache for guild log settings
+const settingsCache = new Map();
+const SETTINGS_CACHE_TTL = 60000; // 1 minute cache
+
+// Default configuration (respects Discord API limits)
+const DEFAULT_FLUSH_INTERVAL = 30;  // seconds
+const DEFAULT_MAX_BUFFER_SIZE = 50;
+const MIN_FLUSH_INTERVAL = 10;      // minimum 10 seconds (API safety)
+const MAX_FLUSH_INTERVAL = 300;     // maximum 5 minutes
+const MIN_BUFFER_SIZE = 10;
+const MAX_BUFFER_SIZE = 100;
+
+// Global flush check interval (checks all guilds)
+const GLOBAL_CHECK_INTERVAL = 5000; // Check every 5 seconds
+
+// Track last flush time per guild
+const lastFlushTime = new Map();
+
+// Embed colors
+const COLORS = {
+    voiceJoin: 0x00ff00,      // green
+    voiceLeave: 0xff0000,     // red
+    voiceMove: 0xffff00,      // yellow
+    nickname: 0x0099ff,       // blue
+    avatar: 0x9900ff,         // purple
+    presenceOnline: 0x43b581, // green
+    presenceIdle: 0xfaa61a,   // orange
+    presenceDnd: 0xf04747,    // red
+    presenceOffline: 0x747f8d // gray
+};
+
+const PRESENCE_COLORS = {
+    online: COLORS.presenceOnline,
+    idle: COLORS.presenceIdle,
+    dnd: COLORS.presenceDnd,
+    offline: COLORS.presenceOffline
+};
+
+const STATUS_EMOJIS = {
+    online: "🟢",
+    idle: "🟡",
+    dnd: "🔴",
+    offline: "⚫"
+};
+
+/**
+ * Get log settings for a guild (with caching)
+ */
+async function getGuildSettings(guildId) {
+    const cached = settingsCache.get(guildId);
+    if (cached && Date.now() - cached.time < SETTINGS_CACHE_TTL) {
+        return cached.settings;
+    }
+
+    try {
+        const settings = await yunoInstance.dbCommands.getLogSettings(yunoInstance.database, guildId);
+        settingsCache.set(guildId, { settings, time: Date.now() });
+        return settings;
+    } catch (e) {
+        return { flushInterval: DEFAULT_FLUSH_INTERVAL, maxBufferSize: DEFAULT_MAX_BUFFER_SIZE };
+    }
+}
+
+/**
+ * Invalidate settings cache for a guild
+ */
+function invalidateSettingsCache(guildId) {
+    settingsCache.delete(guildId);
+}
+
+/**
+ * Get the appropriate log channel for a guild and log type
+ */
+async function getLogChannel(guildId, logType) {
+    try {
+        const logChannels = await yunoInstance.dbCommands.getLogChannels(yunoInstance.database, guildId);
+
+        if (logChannels[logType] && logChannels[logType].enabled && logChannels[logType].channelId) {
+            return logChannels[logType].channelId;
+        }
+
+        if (logChannels.unified && logChannels.unified.enabled && logChannels.unified.channelId) {
+            return logChannels.unified.channelId;
+        }
+
+        return null;
+    } catch (e) {
+        return null;
+    }
+}
+
+/**
+ * Add a log entry to the buffer
+ */
+async function bufferLog(guildId, logType, entry) {
+    if (!logBuffer.has(guildId)) {
+        logBuffer.set(guildId, new Map());
+    }
+
+    const guildBuffer = logBuffer.get(guildId);
+    if (!guildBuffer.has(logType)) {
+        guildBuffer.set(logType, []);
+    }
+
+    guildBuffer.get(logType).push({
+        ...entry,
+        timestamp: Date.now()
+    });
+
+    // Get guild-specific max buffer size
+    const settings = await getGuildSettings(guildId);
+    const maxSize = settings.maxBufferSize || DEFAULT_MAX_BUFFER_SIZE;
+
+    // Force flush if buffer is getting too large
+    if (guildBuffer.get(logType).length >= maxSize) {
+        await flushGuildLogType(guildId, logType);
+    }
+}
+
+/**
+ * Create a compact summary embed for multiple voice events
+ */
+function createVoiceSummaryEmbed(entries) {
+    const embed = new EmbedBuilder()
+        .setTitle("Voice Activity Summary")
+        .setColor(0x7289da)
+        .setTimestamp();
+
+    const joins = entries.filter(e => e.action === "join");
+    const leaves = entries.filter(e => e.action === "leave");
+    const moves = entries.filter(e => e.action === "move");
+
+    let description = "";
+
+    if (joins.length > 0) {
+        description += "**Joined:**\n";
+        description += joins.map(e => `🟢 ${e.userName} → ${e.channel}`).join("\n");
+        description += "\n\n";
+    }
+
+    if (leaves.length > 0) {
+        description += "**Left:**\n";
+        description += leaves.map(e => `🔴 ${e.userName} ← ${e.channel}`).join("\n");
+        description += "\n\n";
+    }
+
+    if (moves.length > 0) {
+        description += "**Moved:**\n";
+        description += moves.map(e => `🟡 ${e.userName}: ${e.fromChannel} → ${e.toChannel}`).join("\n");
+    }
+
+    embed.setDescription(description.trim() || "No activity");
+    embed.setFooter({ text: `${entries.length} events` });
+
+    return embed;
+}
+
+/**
+ * Create a compact summary embed for nickname changes
+ */
+function createNicknameSummaryEmbed(entries) {
+    const embed = new EmbedBuilder()
+        .setTitle("Nickname Changes")
+        .setColor(COLORS.nickname)
+        .setTimestamp();
+
+    const description = entries.map(e =>
+        `**${e.userTag}**\n\`${e.oldNick || "None"}\` → \`${e.newNick || "None"}\``
+    ).join("\n\n");
+
+    embed.setDescription(description || "No changes");
+    embed.setFooter({ text: `${entries.length} changes` });
+
+    return embed;
+}
+
+/**
+ * Create a compact summary embed for presence changes
+ */
+function createPresenceSummaryEmbed(entries) {
+    const embed = new EmbedBuilder()
+        .setTitle("Status Changes")
+        .setColor(0x7289da)
+        .setTimestamp();
+
+    // Group by status transition type
+    const grouped = {};
+    for (const e of entries) {
+        const key = `${e.oldStatus}_${e.newStatus}`;
+        if (!grouped[key]) grouped[key] = [];
+        grouped[key].push(e);
+    }
+
+    let description = "";
+    for (const [transition, users] of Object.entries(grouped)) {
+        const [oldS, newS] = transition.split("_");
+        const emoji = STATUS_EMOJIS[newS] || "⚪";
+        const names = users.map(u => u.userName).join(", ");
+        description += `${emoji} **${oldS} → ${newS}:** ${names}\n`;
+    }
+
+    embed.setDescription(description.trim() || "No changes");
+    embed.setFooter({ text: `${entries.length} changes` });
+
+    return embed;
+}
+
+/**
+ * Create a compact summary embed for avatar changes
+ */
+function createAvatarSummaryEmbed(entries) {
+    const embed = new EmbedBuilder()
+        .setTitle("Avatar Changes")
+        .setColor(COLORS.avatar)
+        .setTimestamp();
+
+    const description = entries.map(e => `• **${e.userTag}** changed their avatar`).join("\n");
+
+    embed.setDescription(description || "No changes");
+    embed.setFooter({ text: `${entries.length} changes` });
+
+    // Show most recent avatar as thumbnail if available
+    if (entries.length > 0 && entries[entries.length - 1].newAvatar) {
+        embed.setThumbnail(entries[entries.length - 1].newAvatar);
+    }
+
+    return embed;
+}
+
+/**
+ * Flush logs for a specific guild and log type
+ */
+async function flushGuildLogType(guildId, logType) {
+    const guildBuffer = logBuffer.get(guildId);
+    if (!guildBuffer) return;
+
+    const entries = guildBuffer.get(logType);
+    if (!entries || entries.length === 0) return;
+
+    // Clear the buffer first
+    guildBuffer.set(logType, []);
+
+    const channelId = await getLogChannel(guildId, logType);
+    if (!channelId) return;
+
+    // Check rate limit
+    const rateLimit = rateLimitState.get(channelId);
+    if (rateLimit && Date.now() < rateLimit.retryAfter) {
+        // Put entries back in buffer to try later
+        const currentBuffer = guildBuffer.get(logType) || [];
+        guildBuffer.set(logType, [...entries, ...currentBuffer]);
+        return;
+    }
+
+    const guild = discClient.guilds.cache.get(guildId);
+    if (!guild) return;
+
+    const channel = guild.channels.cache.get(channelId);
+    if (!channel) return;
+
+    try {
+        let embed;
+
+        switch (logType) {
+            case "voice":
+                embed = createVoiceSummaryEmbed(entries);
+                break;
+            case "nickname":
+                embed = createNicknameSummaryEmbed(entries);
+                break;
+            case "presence":
+                embed = createPresenceSummaryEmbed(entries);
+                break;
+            case "avatar":
+                embed = createAvatarSummaryEmbed(entries);
+                break;
+            default:
+                return;
+        }
+
+        await channel.send({ embeds: [embed] });
+        rateLimitState.delete(channelId);
+
+    } catch (e) {
+        if (e.status === 429 || e.code === 429 || e.message?.includes("rate limit")) {
+            const retryAfter = e.retryAfter || e.retry_after || 10000;
+            rateLimitState.set(channelId, {
+                retryAfter: Date.now() + retryAfter
+            });
+            // Put entries back
+            const currentBuffer = guildBuffer.get(logType) || [];
+            guildBuffer.set(logType, [...entries, ...currentBuffer]);
+        }
+        // Other errors: messages are dropped
+    }
+}
+
+/**
+ * Flush all buffered logs (respects per-guild intervals)
+ */
+async function flushAllLogs() {
+    const now = Date.now();
+
+    for (const [guildId, guildBuffer] of logBuffer.entries()) {
+        // Get guild-specific flush interval
+        const settings = await getGuildSettings(guildId);
+        const flushIntervalMs = (settings.flushInterval || DEFAULT_FLUSH_INTERVAL) * 1000;
+
+        // Check if enough time has passed since last flush for this guild
+        const lastFlush = lastFlushTime.get(guildId) || 0;
+        if (now - lastFlush < flushIntervalMs) {
+            continue; // Not time to flush this guild yet
+        }
+
+        // Flush all log types for this guild
+        let hasFlushed = false;
+        for (const logType of guildBuffer.keys()) {
+            const entries = guildBuffer.get(logType);
+            if (entries && entries.length > 0) {
+                await flushGuildLogType(guildId, logType);
+                hasFlushed = true;
+            }
+        }
+
+        if (hasFlushed) {
+            lastFlushTime.set(guildId, now);
+        }
+    }
+}
+
+/**
+ * Force flush all logs immediately (for shutdown)
+ */
+async function forceFlushAllLogs() {
+    for (const [guildId, guildBuffer] of logBuffer.entries()) {
+        for (const logType of guildBuffer.keys()) {
+            await flushGuildLogType(guildId, logType);
+        }
+    }
+}
+
+/**
+ * Voice state update handler
+ */
+async function onVoiceStateUpdate(oldState, newState) {
+    if (!newState.guild) return;
+    const guildId = newState.guild.id;
+    const member = newState.member;
+    if (!member || member.user.bot) return;
+
+    const oldChannel = oldState.channel;
+    const newChannel = newState.channel;
+
+    // Join
+    if (!oldChannel && newChannel) {
+        bufferLog(guildId, "voice", {
+            action: "join",
+            oderId: member.id,
+            userName: member.displayName,
+            channel: newChannel.name
+        });
+    }
+    // Leave
+    else if (oldChannel && !newChannel) {
+        bufferLog(guildId, "voice", {
+            action: "leave",
+            oderId: member.id,
+            userName: member.displayName,
+            channel: oldChannel.name
+        });
+    }
+    // Move
+    else if (oldChannel && newChannel && oldChannel.id !== newChannel.id) {
+        bufferLog(guildId, "voice", {
+            action: "move",
+            oderId: member.id,
+            userName: member.displayName,
+            fromChannel: oldChannel.name,
+            toChannel: newChannel.name
+        });
+    }
+}
+
+/**
+ * Guild member update handler - logs nickname changes
+ */
+async function onGuildMemberUpdate(oldMember, newMember) {
+    if (!newMember.guild || newMember.user.bot) return;
+
+    if (oldMember.nickname !== newMember.nickname) {
+        bufferLog(newMember.guild.id, "nickname", {
+            oderId: newMember.id,
+            userTag: newMember.user.tag,
+            oldNick: oldMember.nickname,
+            newNick: newMember.nickname
+        });
+    }
+}
+
+/**
+ * User update handler - logs avatar changes
+ */
+async function onUserUpdate(oldUser, newUser) {
+    if (newUser.bot) return;
+
+    if (oldUser.avatar !== newUser.avatar) {
+        // Buffer for all guilds where user is a member
+        for (const guild of discClient.guilds.cache.values()) {
+            if (guild.members.cache.has(newUser.id)) {
+                bufferLog(guild.id, "avatar", {
+                    oderId: newUser.id,
+                    userTag: newUser.tag,
+                    oldAvatar: oldUser.avatar ? oldUser.displayAvatarURL({ size: 128 }) : null,
+                    newAvatar: newUser.displayAvatarURL({ size: 256 })
+                });
+            }
+        }
+    }
+}
+
+/**
+ * Presence update handler
+ */
+async function onPresenceUpdate(oldPresence, newPresence) {
+    if (!newPresence || !newPresence.guild) return;
+
+    const member = newPresence.member;
+    if (!member || member.user.bot) return;
+
+    const oldStatus = oldPresence?.status || "offline";
+    const newStatus = newPresence.status || "offline";
+
+    if (oldStatus === newStatus) return;
+
+    bufferLog(newPresence.guild.id, "presence", {
+        oderId: member.id,
+        userName: member.displayName,
+        oldStatus,
+        newStatus
+    });
+}
+
+let discordConnected = async function(Yuno) {
+    discClient = Yuno.dC;
+    yunoInstance = Yuno;
+
+    if (!DISCORD_EVENTED) {
+        voiceStateHandler = onVoiceStateUpdate;
+        guildMemberUpdateHandler = onGuildMemberUpdate;
+        userUpdateHandler = onUserUpdate;
+        presenceUpdateHandler = onPresenceUpdate;
+
+        discClient.on("voiceStateUpdate", voiceStateHandler);
+        discClient.on("guildMemberUpdate", guildMemberUpdateHandler);
+        discClient.on("userUpdate", userUpdateHandler);
+        discClient.on("presenceUpdate", presenceUpdateHandler);
+
+        // Start global flush check interval (checks per-guild intervals)
+        flushInterval = setInterval(flushAllLogs, GLOBAL_CHECK_INTERVAL);
+    }
+
+    DISCORD_EVENTED = true;
+};
+
+module.exports.init = function(Yuno, hotReloaded) {
+    if (hotReloaded)
+        discordConnected(Yuno);
+    else
+        Yuno.on("discord-connected", discordConnected);
+};
+
+module.exports.configLoaded = function() {};
+
+module.exports.beforeShutdown = async function(Yuno) {
+    // Stop flush interval
+    if (flushInterval) {
+        clearInterval(flushInterval);
+        flushInterval = null;
+    }
+
+    // Force flush remaining logs before shutdown
+    await forceFlushAllLogs();
+
+    // Clear buffers and caches
+    logBuffer.clear();
+    rateLimitState.clear();
+    settingsCache.clear();
+    lastFlushTime.clear();
+
+    if (discClient) {
+        if (voiceStateHandler) {
+            discClient.removeListener("voiceStateUpdate", voiceStateHandler);
+        }
+        if (guildMemberUpdateHandler) {
+            discClient.removeListener("guildMemberUpdate", guildMemberUpdateHandler);
+        }
+        if (userUpdateHandler) {
+            discClient.removeListener("userUpdate", userUpdateHandler);
+        }
+        if (presenceUpdateHandler) {
+            discClient.removeListener("presenceUpdate", presenceUpdateHandler);
+        }
+    }
+
+    DISCORD_EVENTED = false;
+    voiceStateHandler = null;
+    guildMemberUpdateHandler = null;
+    userUpdateHandler = null;
+    presenceUpdateHandler = null;
+};

--- a/src/modules/vc-xp.js
+++ b/src/modules/vc-xp.js
@@ -1,0 +1,330 @@
+/*
+    Yuno Gasai. A Discord.JS based bot, with multiple features.
+    Copyright (C) 2018 Maeeen <maeeennn@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see https://www.gnu.org/licenses/.
+*/
+
+module.exports.modulename = "vc-xp";
+
+let DISCORD_EVENTED = false,
+    discClient = null,
+    yunoInstance = null,
+    voiceStateHandler = null,
+    xpTickInterval = null;
+
+/**
+ * Calculate XP needed for next level
+ * Uses same formula as message XP: 5 * level^2 + 50 * level + 100
+ */
+function calculateNeededXP(level) {
+    return 5 * Math.pow(level, 2) + 50 * level + 100;
+}
+
+/**
+ * Grant XP to a user and handle level ups
+ * Integrates with the main XP system in experiences table
+ */
+async function grantXP(guildId, oderId, xpAmount) {
+    try {
+        const dbCommands = yunoInstance.dbCommands;
+        const db = yunoInstance.database;
+
+        // Get current XP data
+        let xpData = await dbCommands.getXPData(db, guildId, oderId);
+        let neededXP = calculateNeededXP(xpData.level);
+
+        xpData.xp += xpAmount;
+
+        // Handle level ups (possibly multiple)
+        while (xpData.xp >= neededXP) {
+            xpData.level += 1;
+            xpData.xp -= neededXP;
+            neededXP = calculateNeededXP(xpData.level);
+
+            // Try to assign level role if configured
+            await assignLevelRole(guildId, oderId, xpData.level);
+        }
+
+        // Save updated XP
+        await dbCommands.setXPData(db, guildId, oderId, xpData.xp, xpData.level);
+
+        return xpData;
+    } catch (e) {
+        console.error("Error granting VC XP:", e);
+        return null;
+    }
+}
+
+/**
+ * Assign level role to a user if configured
+ */
+async function assignLevelRole(guildId, oderId, level) {
+    try {
+        const dbCommands = yunoInstance.dbCommands;
+        const db = yunoInstance.database;
+
+        const rolemap = await dbCommands.getLevelRoleMap(db, guildId);
+        if (!rolemap || !rolemap[level]) return;
+
+        const guild = discClient.guilds.cache.get(guildId);
+        if (!guild) return;
+
+        const member = guild.members.cache.get(oderId) || await guild.members.fetch(oderId);
+        if (!member) return;
+
+        const role = guild.roles.cache.get(rolemap[level]);
+        if (role && !member.roles.cache.has(role.id)) {
+            await member.roles.add(role);
+        }
+    } catch (e) {
+        // Silently fail if we can't assign role
+    }
+}
+
+/**
+ * Check if a user is in an AFK channel
+ */
+function isInAfkChannel(voiceState, ignoreAfk) {
+    if (!ignoreAfk) return false;
+    if (!voiceState.channel) return false;
+
+    const guild = voiceState.guild;
+    return guild.afkChannelId && voiceState.channelId === guild.afkChannelId;
+}
+
+/**
+ * Voice state update handler - tracks VC sessions
+ */
+async function onVoiceStateUpdate(oldState, newState) {
+    if (!newState.guild) return;
+    const guildId = newState.guild.id;
+    const oderId = newState.member?.id;
+    if (!oderId) return;
+
+    // Ignore bots
+    if (newState.member.user.bot) return;
+
+    const dbCommands = yunoInstance.dbCommands;
+    const db = yunoInstance.database;
+
+    // Check if VC XP is enabled for this guild
+    const config = await dbCommands.getVcXpConfig(db, guildId);
+    if (!config.enabled) return;
+
+    const oldChannel = oldState.channel;
+    const newChannel = newState.channel;
+
+    // Join VC
+    if (!oldChannel && newChannel) {
+        // Don't start session if joining AFK channel
+        if (!isInAfkChannel(newState, config.ignoreAfkChannel)) {
+            await dbCommands.startVcSession(db, guildId, oderId, newChannel.id);
+        }
+    }
+    // Leave VC
+    else if (oldChannel && !newChannel) {
+        // End session and grant XP based on time spent
+        const session = await dbCommands.endVcSession(db, guildId, oderId);
+        if (session) {
+            const now = Date.now();
+            const timeSinceLastGrant = now - session.lastXpGrant;
+            const intervalsEarned = Math.floor(timeSinceLastGrant / (config.intervalSeconds * 1000));
+
+            if (intervalsEarned > 0) {
+                const xpToGrant = intervalsEarned * config.xpPerInterval;
+                await grantXP(guildId, oderId, xpToGrant);
+            }
+        }
+    }
+    // Move between channels
+    else if (oldChannel && newChannel && oldChannel.id !== newChannel.id) {
+        const wasInAfk = isInAfkChannel(oldState, config.ignoreAfkChannel);
+        const nowInAfk = isInAfkChannel(newState, config.ignoreAfkChannel);
+
+        if (wasInAfk && !nowInAfk) {
+            // Moved from AFK to regular channel - start new session
+            await dbCommands.startVcSession(db, guildId, oderId, newChannel.id);
+        } else if (!wasInAfk && nowInAfk) {
+            // Moved to AFK channel - end session and grant XP
+            const session = await dbCommands.endVcSession(db, guildId, oderId);
+            if (session) {
+                const now = Date.now();
+                const timeSinceLastGrant = now - session.lastXpGrant;
+                const intervalsEarned = Math.floor(timeSinceLastGrant / (config.intervalSeconds * 1000));
+
+                if (intervalsEarned > 0) {
+                    const xpToGrant = intervalsEarned * config.xpPerInterval;
+                    await grantXP(guildId, oderId, xpToGrant);
+                }
+            }
+        } else if (!nowInAfk) {
+            // Regular move - just update channel
+            await dbCommands.updateVcSessionChannel(db, guildId, oderId, newChannel.id);
+        }
+    }
+}
+
+/**
+ * Periodic XP tick - grants XP to users in VC at regular intervals
+ * This ensures users get XP even during long sessions
+ */
+async function xpTick() {
+    try {
+        const dbCommands = yunoInstance.dbCommands;
+        const db = yunoInstance.database;
+
+        // Process each guild
+        for (const guild of discClient.guilds.cache.values()) {
+            const config = await dbCommands.getVcXpConfig(db, guild.id);
+            if (!config.enabled) continue;
+
+            const sessions = await dbCommands.getGuildVcSessions(db, guild.id);
+            const now = Date.now();
+
+            for (const session of sessions) {
+                const timeSinceLastGrant = now - session.lastXpGrant;
+                const intervalsEarned = Math.floor(timeSinceLastGrant / (config.intervalSeconds * 1000));
+
+                if (intervalsEarned > 0) {
+                    // Check if user is still in VC and not in AFK channel
+                    const member = guild.members.cache.get(session.oderId);
+                    if (member && member.voice.channel) {
+                        const isAfk = config.ignoreAfkChannel &&
+                            guild.afkChannelId &&
+                            member.voice.channelId === guild.afkChannelId;
+
+                        if (!isAfk) {
+                            const xpToGrant = intervalsEarned * config.xpPerInterval;
+                            await grantXP(guild.id, session.oderId, xpToGrant);
+
+                            // Update last XP grant time
+                            const newLastGrant = session.lastXpGrant + (intervalsEarned * config.intervalSeconds * 1000);
+                            await dbCommands.updateVcSessionXpTime(db, guild.id, session.oderId, newLastGrant);
+                        }
+                    } else {
+                        // User no longer in VC - clean up stale session
+                        await dbCommands.endVcSession(db, guild.id, session.oderId);
+                    }
+                }
+            }
+        }
+    } catch (e) {
+        console.error("Error in VC XP tick:", e);
+    }
+}
+
+/**
+ * Recover existing VC sessions on bot startup
+ * Creates sessions for users already in voice channels
+ */
+async function recoverSessions() {
+    try {
+        const dbCommands = yunoInstance.dbCommands;
+        const db = yunoInstance.database;
+
+        // Clear stale sessions first
+        await dbCommands.clearAllVcSessions(db);
+
+        // Create sessions for users currently in voice
+        for (const guild of discClient.guilds.cache.values()) {
+            const config = await dbCommands.getVcXpConfig(db, guild.id);
+            if (!config.enabled) continue;
+
+            for (const voiceState of guild.voiceStates.cache.values()) {
+                if (!voiceState.channel) continue;
+                if (voiceState.member?.user.bot) continue;
+
+                // Skip if in AFK channel
+                if (config.ignoreAfkChannel && guild.afkChannelId && voiceState.channelId === guild.afkChannelId) {
+                    continue;
+                }
+
+                await dbCommands.startVcSession(db, guild.id, voiceState.member.id, voiceState.channelId);
+            }
+        }
+    } catch (e) {
+        console.error("Error recovering VC sessions:", e);
+    }
+}
+
+let discordConnected = async function(Yuno) {
+    discClient = Yuno.dC;
+    yunoInstance = Yuno;
+
+    if (!DISCORD_EVENTED) {
+        voiceStateHandler = onVoiceStateUpdate;
+        discClient.on("voiceStateUpdate", voiceStateHandler);
+
+        // Start XP tick interval (every 60 seconds)
+        xpTickInterval = setInterval(xpTick, 60 * 1000);
+    }
+
+    DISCORD_EVENTED = true;
+
+    // Recover sessions for users already in VC
+    await recoverSessions();
+};
+
+module.exports.init = function(Yuno, hotReloaded) {
+    if (hotReloaded)
+        discordConnected(Yuno);
+    else
+        Yuno.on("discord-connected", discordConnected);
+};
+
+module.exports.configLoaded = function() {};
+
+module.exports.beforeShutdown = async function(Yuno) {
+    if (discClient && voiceStateHandler) {
+        discClient.removeListener("voiceStateUpdate", voiceStateHandler);
+    }
+
+    if (xpTickInterval) {
+        clearInterval(xpTickInterval);
+        xpTickInterval = null;
+    }
+
+    // Grant remaining XP to all users currently in VC before shutdown
+    try {
+        const dbCommands = Yuno.dbCommands;
+        const db = Yuno.database;
+
+        for (const guild of discClient.guilds.cache.values()) {
+            const config = await dbCommands.getVcXpConfig(db, guild.id);
+            if (!config.enabled) continue;
+
+            const sessions = await dbCommands.getGuildVcSessions(db, guild.id);
+            const now = Date.now();
+
+            for (const session of sessions) {
+                const timeSinceLastGrant = now - session.lastXpGrant;
+                const intervalsEarned = Math.floor(timeSinceLastGrant / (config.intervalSeconds * 1000));
+
+                if (intervalsEarned > 0) {
+                    const xpToGrant = intervalsEarned * config.xpPerInterval;
+                    await grantXP(guild.id, session.oderId, xpToGrant);
+                }
+            }
+        }
+
+        // Clear all sessions
+        await dbCommands.clearAllVcSessions(db);
+    } catch (e) {
+        console.error("Error during VC XP shutdown:", e);
+    }
+
+    DISCORD_EVENTED = false;
+    voiceStateHandler = null;
+};


### PR DESCRIPTION
## Summary

- **Activity Logging Module** - Log server activity with smart batching to respect Discord rate limits
  - Voice channel join/leave/move events
  - Nickname changes
  - Avatar/profile picture changes
  - Presence status changes (online/offline/idle/dnd)
  - Configurable per-guild flush intervals (10-300s) and buffer sizes (10-100 entries)

- **Voice Channel XP System** - Reward users for time spent in voice channels
  - Configurable XP rate and interval per guild
  - AFK channel exclusion option
  - Integrates with existing XP/leveling system
  - Session recovery on bot restart

## New Commands

| Command | Description |
|---------|-------------|
| `set-logchannel <type> <#channel>` | Configure logging channels (unified/voice/nickname/avatar/presence) |
| `log-status` | View current logging configuration |
| `set-logsettings` | Configure batching settings (interval/buffer) |
| `set-vcxp` | Configure voice channel XP (enable/disable/rate/interval/ignore-afk) |
| `vcxp-status` | View VC XP config and active sessions |

## Other Changes

- Added `GuildVoiceStates` and `GuildPresences` intents to Yuno.js
- Increased EventEmitter max listeners to 20 (accommodates new modules)
- Fixed `Yuno is not defined` error in spam filter modules (uses `msg.client` instead)
- Updated README with documentation for new features

## Test plan

- [ ] Set up log channels with `.set-logchannel unified #logs`
- [ ] Verify voice events are logged when users join/leave/move voice channels
- [ ] Verify nickname and avatar changes are logged
- [ ] Verify presence changes are logged (requires PRESENCE INTENT enabled)
- [ ] Test `.set-logsettings interval 15` and verify faster flushing
- [ ] Enable VC XP with `.set-vcxp enable` and verify XP is granted
- [ ] Verify AFK channel is ignored when `ignore-afk` is enabled
- [ ] Restart bot and verify VC sessions are recovered

🤖 Generated with [Claude Code](https://claude.com/claude-code)