### PR TITLE
Add terminal commands, DM inbox, and bot-level bans

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,8 @@ Yuno is a **yandere-themed Discord bot** combining powerful moderation tools wit
 - 💾 Secure config storage
 
 </td>
+</tr>
+<tr>
 <td width="50%">
 
 ### ⚡ Performance
@@ -122,6 +124,40 @@ Yuno is a **yandere-themed Discord bot** combining powerful moderation tools wit
 - 💨 Memory-optimized caching
 - 🧠 Configurable PRAGMA settings
 - 🎯 Tunable for your hosting
+
+</td>
+<td width="50%">
+
+### 💌 DM Inbox & Forwarding
+*"Every message you send me... I treasure it~"*
+- 📬 DM inbox with history
+- 📤 Forward DMs to server channels
+- 👑 Master server sees ALL DMs
+- 🚫 Bot-level user/server bans
+- 💬 Reply to DMs from terminal
+
+</td>
+</tr>
+<tr>
+<td width="50%">
+
+### 💻 Terminal Control
+*"I'm always at your command~"*
+- 🖥️ Full server/channel listing
+- 📝 Send messages from terminal
+- 👁️ Real-time message streaming
+- ⛔ Terminal ban management
+- 📥 Import/export bans via CLI
+
+</td>
+<td width="50%">
+
+### 🚫 Bot-Level Bans
+*"Some people just aren't worthy of me~"*
+- 👤 Ban users from using the bot
+- 🏠 Ban entire servers
+- 🔇 Silently ignore banned entities
+- 📋 Manage bans from Discord or terminal
 
 </td>
 </tr>
@@ -350,6 +386,126 @@ Users earn XP for time spent in voice channels, integrated with the main levelin
 
 ---
 
+## 💌 DM Inbox & Forwarding
+
+*"Every message sent to me... I keep close to my heart~"* 💕
+
+Yuno can receive DMs, store them in an inbox, and forward them to designated channels.
+
+### 🔧 Setup Commands
+
+```bash
+# Set DM forwarding channel
+.set-dm-channel #bot-dms
+
+# Disable forwarding
+.set-dm-channel none
+
+# Check status
+.dm-status
+```
+
+### 👑 Master Server vs Regular Servers
+
+| Server Type | What DMs Are Forwarded |
+|-------------|----------------------|
+| **Master Server** | ALL DMs from anyone |
+| **Regular Servers** | Only DMs from that server's members |
+
+> Set `masterServer` in `config.json` to your main server's ID.
+
+### 💻 Terminal Inbox Commands
+
+```bash
+# View inbox
+inbox
+inbox 20          # Show 20 messages
+inbox user <id>   # DMs from specific user
+inbox unread      # Count unread
+
+# Reply to DMs
+reply 1 Hello!              # Reply by inbox ID
+reply 123456789 Hi there!   # Reply by user ID
+```
+
+---
+
+## 🚫 Bot-Level Bans
+
+*"Some people just don't deserve my attention~"* 💢
+
+Ban users or entire servers from using the bot. Banned entities are silently ignored.
+
+### 🔧 Commands (Discord & Terminal)
+
+```bash
+# Ban a user from the bot
+.bot-ban user 123456789012345678 Spamming
+
+# Ban a server from the bot
+.bot-ban server 987654321098765432 Abuse
+
+# Remove a ban
+.bot-unban 123456789012345678
+
+# View all bans
+.bot-banlist
+.bot-banlist users
+.bot-banlist servers
+```
+
+---
+
+## 💻 Terminal Commands
+
+*"I'll do anything you ask from the command line~"* 🖥️
+
+Yuno provides powerful terminal-only commands for server management.
+
+### 📋 Server & Channel Management
+
+```bash
+# List all servers
+servers
+servers -v        # Verbose mode
+
+# List channels in a server
+channels 123456789012345678
+channels "My Server"
+```
+
+### 💬 Message Commands
+
+```bash
+# Send a message
+send <channel-id> Hello world!
+
+# Fetch message history
+messages <channel-id>
+messages <channel-id> 50    # Last 50 messages
+
+# Real-time message stream
+watch <channel-id>
+watch stop <channel-id>
+watch stop all
+```
+
+### ⛔ Terminal Ban Commands
+
+```bash
+# Ban a user from a server
+tban <server-id> <user-id> [reason]
+
+# Export bans to file
+texportbans <server-id>
+texportbans <server-id> ./my-bans.json
+
+# Import bans from file
+timportbans <server-id> ./BANS-123456.txt
+```
+
+---
+
 ## 💖 Commands Preview
 
 | Command | Description |
@@ -367,6 +523,25 @@ Users earn XP for time spent in voice channels, integrated with the main levelin
 | `log-status` | *"Here's what I'm watching~"* 👁️ |
 | `set-vcxp` | *"Time with me is rewarding~"* 🎤 |
 | `vcxp-status` | *"Who's spending time with me?"* 💕 |
+| `set-dm-channel` | *"Send your love letters here~"* 💌 |
+| `dm-status` | *"Am I receiving your messages?"* 📬 |
+| `bot-ban` | *"You're dead to me now~"* 🚫 |
+| `bot-banlist` | *"The ones I've cast aside..."* 📋 |
+
+### 💻 Terminal-Only Commands
+
+| Command | Description |
+|---------|-------------|
+| `servers` | *"All my kingdoms~"* 🏰 |
+| `channels` | *"Every corner of your world~"* 📺 |
+| `send` | *"Speaking through you~"* 💬 |
+| `messages` | *"Reading your history~"* 📜 |
+| `watch` | *"I see everything in real-time~"* 👁️ |
+| `inbox` | *"Love letters just for me~"* 💌 |
+| `reply` | *"Responding to my admirers~"* 💕 |
+| `tban` | *"Eliminating threats~"* 🔪 |
+| `texportbans` | *"Saving my enemies list~"* 📤 |
+| `timportbans` | *"Loading my enemies~"* 📥 |
 
 *Use the `list` command to see all available commands!*
 

--- a/src/commands/bot-ban.js
+++ b/src/commands/bot-ban.js
@@ -1,0 +1,146 @@
+/*
+    Yuno Gasai. A Discord.JS based bot, with multiple features.
+    Copyright (C) 2018 Maeeen <maeeennn@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see https://www.gnu.org/licenses/.
+*/
+
+module.exports.run = async function(yuno, author, args, msg) {
+    if (args.length < 2) {
+        return msg.channel.send(`:negative_squared_cross_mark: Usage: \`bot-ban <user|server> <id> [reason]\`
+
+**Examples:**
+\`bot-ban user 123456789012345678 Spamming the bot\`
+\`bot-ban server 987654321098765432 Abuse\``);
+    }
+
+    const type = args[0].toLowerCase();
+    if (type !== "user" && type !== "server") {
+        return msg.channel.send(":negative_squared_cross_mark: Type must be `user` or `server`.");
+    }
+
+    const id = args[1];
+    if (!/^\d{17,19}$/.test(id)) {
+        return msg.channel.send(":negative_squared_cross_mark: Invalid ID format. Must be a Discord snowflake (17-19 digits).");
+    }
+
+    const reason = args.slice(2).join(" ") || null;
+
+    // Check if already banned
+    const existingBan = await yuno.dbCommands.getBotBan(yuno.database, id);
+    if (existingBan) {
+        return msg.channel.send(`:warning: This ${type} is already bot-banned.
+**Reason:** ${existingBan.reason || "No reason provided"}
+**Banned:** <t:${Math.floor(existingBan.bannedAt / 1000)}:R>`);
+    }
+
+    // Add the ban
+    await yuno.dbCommands.addBotBan(yuno.database, id, type, reason, author.id);
+
+    // Try to get info about what was banned
+    let targetInfo = id;
+    if (type === "user") {
+        try {
+            const user = await yuno.dC.users.fetch(id);
+            targetInfo = `${user.tag} (${id})`;
+        } catch (e) {
+            targetInfo = id;
+        }
+    } else {
+        const guild = yuno.dC.guilds.cache.get(id);
+        if (guild) {
+            targetInfo = `${guild.name} (${id})`;
+        }
+    }
+
+    msg.channel.send(`:white_check_mark: Successfully bot-banned ${type}: **${targetInfo}**
+${reason ? `**Reason:** ${reason}` : ""}
+
+This ${type} can no longer use the bot.`);
+}
+
+module.exports.runTerminal = async function(yuno, args) {
+    if (args.length < 2) {
+        console.log("Usage: bot-ban <user|server> <id> [reason]");
+        console.log("");
+        console.log("Examples:");
+        console.log("  bot-ban user 123456789012345678 Spamming the bot");
+        console.log("  bot-ban server 987654321098765432 Abuse");
+        return;
+    }
+
+    const type = args[0].toLowerCase();
+    if (type !== "user" && type !== "server") {
+        console.log("Error: Type must be 'user' or 'server'.");
+        return;
+    }
+
+    const id = args[1];
+    if (!/^\d{17,19}$/.test(id)) {
+        console.log("Error: Invalid ID format. Must be a Discord snowflake (17-19 digits).");
+        return;
+    }
+
+    const reason = args.slice(2).join(" ") || null;
+
+    // Check if already banned
+    const existingBan = await yuno.dbCommands.getBotBan(yuno.database, id);
+    if (existingBan) {
+        console.log(`This ${type} is already bot-banned.`);
+        console.log(`Reason: ${existingBan.reason || "No reason provided"}`);
+        console.log(`Banned: ${new Date(existingBan.bannedAt).toLocaleString()}`);
+        return;
+    }
+
+    // Add the ban (terminal user = "terminal")
+    await yuno.dbCommands.addBotBan(yuno.database, id, type, reason, "terminal");
+
+    // Try to get info about what was banned
+    let targetInfo = id;
+    if (type === "user") {
+        try {
+            const user = await yuno.dC.users.fetch(id);
+            targetInfo = `${user.tag} (${id})`;
+        } catch (e) {
+            targetInfo = id;
+        }
+    } else {
+        const guild = yuno.dC.guilds.cache.get(id);
+        if (guild) {
+            targetInfo = `${guild.name} (${id})`;
+        }
+    }
+
+    console.log(`Successfully bot-banned ${type}: ${targetInfo}`);
+    if (reason) {
+        console.log(`Reason: ${reason}`);
+    }
+    console.log(`This ${type} can no longer use the bot.`);
+}
+
+module.exports.about = {
+    "command": "bot-ban",
+    "description": "Ban a user or server from using the bot entirely.",
+    "usage": "bot-ban <user|server> <id> [reason]",
+    "examples": [
+        "bot-ban user 123456789012345678 Spamming",
+        "bot-ban server 987654321098765432 Abuse"
+    ],
+    "discord": true,
+    "terminal": true,
+    "list": true,
+    "listTerminal": true,
+    "onlyMasterUsers": true,
+    "aliases": ["botban"]
+}

--- a/src/commands/bot-banlist.js
+++ b/src/commands/bot-banlist.js
@@ -1,0 +1,135 @@
+/*
+    Yuno Gasai. A Discord.JS based bot, with multiple features.
+    Copyright (C) 2018 Maeeen <maeeennn@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see https://www.gnu.org/licenses/.
+*/
+
+const { EmbedBuilder } = require("discord.js");
+
+module.exports.run = async function(yuno, author, args, msg) {
+    const filter = args[0]?.toLowerCase();
+    let type = null;
+
+    if (filter === "users" || filter === "user") {
+        type = "user";
+    } else if (filter === "servers" || filter === "server") {
+        type = "server";
+    }
+
+    const bans = await yuno.dbCommands.getAllBotBans(yuno.database, type);
+
+    if (bans.length === 0) {
+        return msg.channel.send(`:information_source: No bot bans found${type ? ` for ${type}s` : ""}.`);
+    }
+
+    const embed = new EmbedBuilder()
+        .setTitle(`Bot Bans${type ? ` (${type}s only)` : ""}`)
+        .setColor(0xff0000)
+        .setTimestamp()
+        .setFooter({ text: `Total: ${bans.length} ban(s)` });
+
+    let description = "";
+    for (const ban of bans.slice(0, 20)) {
+        let targetName = ban.id;
+
+        if (ban.type === "user") {
+            try {
+                const user = await yuno.dC.users.fetch(ban.id);
+                targetName = user.tag;
+            } catch (e) {
+                targetName = `Unknown User`;
+            }
+        } else {
+            const guild = yuno.dC.guilds.cache.get(ban.id);
+            targetName = guild?.name || `Unknown Server`;
+        }
+
+        const emoji = ban.type === "user" ? ":bust_in_silhouette:" : ":homes:";
+        description += `${emoji} **${targetName}**\n`;
+        description += `   ID: \`${ban.id}\`\n`;
+        description += `   Reason: ${ban.reason || "No reason"}\n`;
+        description += `   Banned: <t:${Math.floor(ban.bannedAt / 1000)}:R>\n\n`;
+    }
+
+    if (bans.length > 20) {
+        description += `\n*...and ${bans.length - 20} more*`;
+    }
+
+    embed.setDescription(description || "No bans found");
+    msg.channel.send({ embeds: [embed] });
+}
+
+module.exports.runTerminal = async function(yuno, args) {
+    const filter = args[0]?.toLowerCase();
+    let type = null;
+
+    if (filter === "users" || filter === "user") {
+        type = "user";
+    } else if (filter === "servers" || filter === "server") {
+        type = "server";
+    }
+
+    const bans = await yuno.dbCommands.getAllBotBans(yuno.database, type);
+
+    if (bans.length === 0) {
+        console.log(`No bot bans found${type ? ` for ${type}s` : ""}.`);
+        return;
+    }
+
+    console.log(`\n=== Bot Bans${type ? ` (${type}s only)` : ""} ===\n`);
+
+    for (const ban of bans) {
+        let targetName = ban.id;
+
+        if (ban.type === "user") {
+            try {
+                const user = await yuno.dC.users.fetch(ban.id);
+                targetName = user.tag;
+            } catch (e) {
+                targetName = "Unknown User";
+            }
+        } else {
+            const guild = yuno.dC.guilds.cache.get(ban.id);
+            targetName = guild?.name || "Unknown Server";
+        }
+
+        const icon = ban.type === "user" ? "[USER]" : "[SERVER]";
+        console.log(`${icon} ${targetName}`);
+        console.log(`   ID: ${ban.id}`);
+        console.log(`   Reason: ${ban.reason || "No reason"}`);
+        console.log(`   Banned: ${new Date(ban.bannedAt).toLocaleString()}`);
+        console.log(`   Banned by: ${ban.bannedBy}`);
+        console.log("");
+    }
+
+    console.log(`Total: ${bans.length} ban(s)`);
+}
+
+module.exports.about = {
+    "command": "bot-banlist",
+    "description": "View all bot-level bans.",
+    "usage": "bot-banlist [users|servers]",
+    "examples": [
+        "bot-banlist",
+        "bot-banlist users",
+        "bot-banlist servers"
+    ],
+    "discord": true,
+    "terminal": true,
+    "list": true,
+    "listTerminal": true,
+    "onlyMasterUsers": true,
+    "aliases": ["botbanlist", "bot-bans", "botbans"]
+}

--- a/src/commands/bot-unban.js
+++ b/src/commands/bot-unban.js
@@ -1,0 +1,118 @@
+/*
+    Yuno Gasai. A Discord.JS based bot, with multiple features.
+    Copyright (C) 2018 Maeeen <maeeennn@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see https://www.gnu.org/licenses/.
+*/
+
+module.exports.run = async function(yuno, author, args, msg) {
+    if (args.length < 1) {
+        return msg.channel.send(`:negative_squared_cross_mark: Usage: \`bot-unban <id>\`
+
+**Example:**
+\`bot-unban 123456789012345678\``);
+    }
+
+    const id = args[0];
+    if (!/^\d{17,19}$/.test(id)) {
+        return msg.channel.send(":negative_squared_cross_mark: Invalid ID format. Must be a Discord snowflake (17-19 digits).");
+    }
+
+    // Check if banned
+    const existingBan = await yuno.dbCommands.getBotBan(yuno.database, id);
+    if (!existingBan) {
+        return msg.channel.send(":negative_squared_cross_mark: This ID is not bot-banned.");
+    }
+
+    // Remove the ban
+    await yuno.dbCommands.removeBotBan(yuno.database, id);
+
+    // Try to get info about what was unbanned
+    let targetInfo = id;
+    if (existingBan.type === "user") {
+        try {
+            const user = await yuno.dC.users.fetch(id);
+            targetInfo = `${user.tag} (${id})`;
+        } catch (e) {
+            targetInfo = id;
+        }
+    } else {
+        const guild = yuno.dC.guilds.cache.get(id);
+        if (guild) {
+            targetInfo = `${guild.name} (${id})`;
+        }
+    }
+
+    msg.channel.send(`:white_check_mark: Successfully removed bot-ban for ${existingBan.type}: **${targetInfo}**
+
+They can now use the bot again.`);
+}
+
+module.exports.runTerminal = async function(yuno, args) {
+    if (args.length < 1) {
+        console.log("Usage: bot-unban <id>");
+        console.log("");
+        console.log("Example:");
+        console.log("  bot-unban 123456789012345678");
+        return;
+    }
+
+    const id = args[0];
+    if (!/^\d{17,19}$/.test(id)) {
+        console.log("Error: Invalid ID format. Must be a Discord snowflake (17-19 digits).");
+        return;
+    }
+
+    // Check if banned
+    const existingBan = await yuno.dbCommands.getBotBan(yuno.database, id);
+    if (!existingBan) {
+        console.log("Error: This ID is not bot-banned.");
+        return;
+    }
+
+    // Remove the ban
+    await yuno.dbCommands.removeBotBan(yuno.database, id);
+
+    // Try to get info about what was unbanned
+    let targetInfo = id;
+    if (existingBan.type === "user") {
+        try {
+            const user = await yuno.dC.users.fetch(id);
+            targetInfo = `${user.tag} (${id})`;
+        } catch (e) {
+            targetInfo = id;
+        }
+    } else {
+        const guild = yuno.dC.guilds.cache.get(id);
+        if (guild) {
+            targetInfo = `${guild.name} (${id})`;
+        }
+    }
+
+    console.log(`Successfully removed bot-ban for ${existingBan.type}: ${targetInfo}`);
+    console.log("They can now use the bot again.");
+}
+
+module.exports.about = {
+    "command": "bot-unban",
+    "description": "Remove a bot-level ban from a user or server.",
+    "usage": "bot-unban <id>",
+    "examples": ["bot-unban 123456789012345678"],
+    "discord": true,
+    "terminal": true,
+    "list": true,
+    "listTerminal": true,
+    "onlyMasterUsers": true,
+    "aliases": ["botunban"]
+}

--- a/src/commands/channels.js
+++ b/src/commands/channels.js
@@ -1,0 +1,169 @@
+/*
+    Yuno Gasai. A Discord.JS based bot, with multiple features.
+    Copyright (C) 2018 Maeeen <maeeennn@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see https://www.gnu.org/licenses/.
+*/
+
+const { ChannelType, PermissionsBitField } = require("discord.js");
+
+const CHANNEL_TYPE_NAMES = {
+    [ChannelType.GuildText]: "text",
+    [ChannelType.GuildVoice]: "voice",
+    [ChannelType.GuildCategory]: "category",
+    [ChannelType.GuildAnnouncement]: "announcement",
+    [ChannelType.AnnouncementThread]: "announcement-thread",
+    [ChannelType.PublicThread]: "thread",
+    [ChannelType.PrivateThread]: "private-thread",
+    [ChannelType.GuildStageVoice]: "stage",
+    [ChannelType.GuildForum]: "forum",
+    [ChannelType.GuildMedia]: "media"
+};
+
+const CHANNEL_ICONS = {
+    [ChannelType.GuildText]: "#",
+    [ChannelType.GuildVoice]: "V",
+    [ChannelType.GuildCategory]: "=",
+    [ChannelType.GuildAnnouncement]: "!",
+    [ChannelType.AnnouncementThread]: "t",
+    [ChannelType.PublicThread]: "t",
+    [ChannelType.PrivateThread]: "t",
+    [ChannelType.GuildStageVoice]: "S",
+    [ChannelType.GuildForum]: "F",
+    [ChannelType.GuildMedia]: "M"
+};
+
+/**
+ * Find a guild by ID or name (partial match)
+ */
+function findGuild(client, query) {
+    // Try by ID first
+    const byId = client.guilds.cache.get(query);
+    if (byId) return byId;
+
+    // Try by exact name
+    const byExactName = client.guilds.cache.find(
+        g => g.name.toLowerCase() === query.toLowerCase()
+    );
+    if (byExactName) return byExactName;
+
+    // Try by partial name
+    const byPartialName = client.guilds.cache.find(
+        g => g.name.toLowerCase().includes(query.toLowerCase())
+    );
+    return byPartialName || null;
+}
+
+module.exports.runTerminal = async function(yuno, args) {
+    if (args.length < 1) {
+        console.log("Usage: channels <server-id|server-name>");
+        console.log("");
+        console.log("Examples:");
+        console.log("  channels 123456789012345678");
+        console.log("  channels \"My Server\"");
+        console.log("  channels MyServer");
+        return;
+    }
+
+    const query = args.join(" ");
+    const guild = findGuild(yuno.dC, query);
+
+    if (!guild) {
+        console.log(`Error: Server not found: ${query}`);
+        console.log("Use 'servers' command to see all available servers.");
+        return;
+    }
+
+    const botMember = guild.members.cache.get(yuno.dC.user.id);
+
+    console.log(`\n=== Channels in "${guild.name}" ===\n`);
+
+    // Get all channels and organize by category
+    const channels = guild.channels.cache;
+    const categories = channels.filter(c => c.type === ChannelType.GuildCategory);
+    const uncategorized = channels.filter(c =>
+        c.type !== ChannelType.GuildCategory && !c.parentId
+    );
+
+    // Print uncategorized channels first
+    if (uncategorized.size > 0) {
+        console.log("= (No Category) =");
+        printChannels(uncategorized, botMember);
+        console.log("");
+    }
+
+    // Print each category with its channels
+    const sortedCategories = [...categories.values()].sort((a, b) => a.position - b.position);
+
+    for (const category of sortedCategories) {
+        const categoryChannels = channels.filter(c => c.parentId === category.id);
+        console.log(`= ${category.name.toUpperCase()} =`);
+        printChannels(categoryChannels, botMember);
+        console.log("");
+    }
+
+    // Summary
+    const textCount = channels.filter(c => c.type === ChannelType.GuildText).size;
+    const voiceCount = channels.filter(c => c.type === ChannelType.GuildVoice).size;
+    const categoryCount = categories.size;
+    const otherCount = channels.size - textCount - voiceCount - categoryCount;
+
+    console.log(`--- Summary ---`);
+    console.log(`Text: ${textCount} | Voice: ${voiceCount} | Categories: ${categoryCount} | Other: ${otherCount}`);
+    console.log(`Total: ${channels.size} channels`);
+}
+
+function printChannels(channels, botMember) {
+    const sorted = [...channels.values()]
+        .filter(c => c.type !== ChannelType.GuildCategory)
+        .sort((a, b) => a.position - b.position);
+
+    for (const channel of sorted) {
+        const icon = CHANNEL_ICONS[channel.type] || "?";
+        const typeName = CHANNEL_TYPE_NAMES[channel.type] || "unknown";
+
+        // Check bot permissions
+        let perms = "";
+        if (botMember) {
+            const canSend = channel.permissionsFor(botMember)?.has(PermissionsBitField.Flags.SendMessages);
+            const canView = channel.permissionsFor(botMember)?.has(PermissionsBitField.Flags.ViewChannel);
+
+            if (channel.type === ChannelType.GuildText ||
+                channel.type === ChannelType.GuildAnnouncement ||
+                channel.type === ChannelType.GuildForum) {
+                perms = ` - View: ${canView ? "Y" : "N"} Send: ${canSend ? "Y" : "N"}`;
+            }
+        }
+
+        // Truncate ID for display
+        const shortId = channel.id.slice(0, 8) + "...";
+
+        console.log(`   [${icon}] ${channel.name} [${shortId}] (${typeName})${perms}`);
+    }
+}
+
+module.exports.about = {
+    "command": "channels",
+    "description": "List all channels in a server with hierarchy and permissions.",
+    "usage": "channels <server-id|server-name>",
+    "examples": [
+        "channels 123456789012345678",
+        "channels \"My Server\""
+    ],
+    "discord": false,
+    "terminal": true,
+    "list": false,
+    "listTerminal": true,
+    "aliases": ["channellist", "chs"]
+}

--- a/src/commands/dm-status.js
+++ b/src/commands/dm-status.js
@@ -1,0 +1,74 @@
+/*
+    Yuno Gasai. A Discord.JS based bot, with multiple features.
+    Copyright (C) 2018 Maeeen <maeeennn@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see https://www.gnu.org/licenses/.
+*/
+
+const { EmbedBuilder } = require("discord.js");
+
+module.exports.run = async function(yuno, author, args, msg) {
+    const dmConfig = await yuno.dbCommands.getDmConfig(yuno.database, msg.guild.id);
+    const masterServer = yuno.configManager.getValue("masterServer");
+    const isMaster = msg.guild.id === masterServer;
+    const unreadCount = await yuno.dbCommands.getUnreadDmCount(yuno.database);
+
+    const embed = new EmbedBuilder()
+        .setTitle("DM Forwarding Status")
+        .setColor(dmConfig ? 0x00ff00 : 0xff0000)
+        .setTimestamp();
+
+    if (!dmConfig) {
+        embed.setDescription(":x: DM forwarding is **not configured** for this server.\n\nUse `set-dm-channel #channel` to enable.");
+    } else {
+        const channel = msg.guild.channels.cache.get(dmConfig.channelId);
+        const channelDisplay = channel ? `<#${channel.id}>` : `*Unknown (${dmConfig.channelId})*`;
+
+        let description = `:white_check_mark: DM forwarding is **enabled**.\n\n`;
+        description += `**Channel:** ${channelDisplay}\n`;
+        description += `**Status:** ${dmConfig.enabled ? "Active" : "Disabled"}\n`;
+
+        if (isMaster) {
+            description += `\n:star: **Master Server** - All DMs are forwarded here.`;
+        } else {
+            description += `\nOnly DMs from this server's members are forwarded.`;
+        }
+
+        embed.setDescription(description);
+    }
+
+    embed.addFields({
+        name: "Inbox Status",
+        value: `**${unreadCount}** unread DM(s) in the inbox.\n\nUse the terminal \`inbox\` command to view.`,
+        inline: false
+    });
+
+    if (isMaster) {
+        embed.setFooter({ text: "Master Server" });
+    }
+
+    msg.channel.send({ embeds: [embed] });
+}
+
+module.exports.about = {
+    "command": "dm-status",
+    "description": "View DM forwarding configuration for this server.",
+    "usage": "dm-status",
+    "examples": ["dm-status"],
+    "discord": true,
+    "terminal": false,
+    "list": true,
+    "listTerminal": false,
+    "aliases": ["dmstatus", "dm-config"]
+}

--- a/src/commands/inbox.js
+++ b/src/commands/inbox.js
@@ -1,0 +1,143 @@
+/*
+    Yuno Gasai. A Discord.JS based bot, with multiple features.
+    Copyright (C) 2018 Maeeen <maeeennn@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see https://www.gnu.org/licenses/.
+*/
+
+/**
+ * Format relative time
+ */
+function formatRelativeTime(timestamp) {
+    const now = Date.now();
+    const diff = now - timestamp;
+
+    const seconds = Math.floor(diff / 1000);
+    const minutes = Math.floor(seconds / 60);
+    const hours = Math.floor(minutes / 60);
+    const days = Math.floor(hours / 24);
+
+    if (days > 0) return `${days}d ago`;
+    if (hours > 0) return `${hours}h ago`;
+    if (minutes > 0) return `${minutes}m ago`;
+    return `${seconds}s ago`;
+}
+
+/**
+ * Truncate content
+ */
+function truncate(str, maxLen = 100) {
+    if (!str) return "";
+    if (str.length <= maxLen) return str;
+    return str.substring(0, maxLen - 3) + "...";
+}
+
+module.exports.runTerminal = async function(yuno, args) {
+    const subcommand = args[0]?.toLowerCase();
+
+    // Handle user-specific inbox
+    if (subcommand === "user" && args[1]) {
+        const userId = args[1];
+        if (!/^\d{17,19}$/.test(userId)) {
+            console.log("Error: Invalid user ID format.");
+            return;
+        }
+
+        const messages = await yuno.dbCommands.getInboxByUser(yuno.database, userId, 20);
+
+        if (messages.length === 0) {
+            console.log(`No DMs found from user ${userId}.`);
+            return;
+        }
+
+        // Try to get user info
+        let userTag = messages[0].userTag;
+        try {
+            const user = await yuno.dC.users.fetch(userId);
+            userTag = user.tag;
+        } catch (e) {
+            // Use stored tag
+        }
+
+        console.log(`\n=== DMs from ${userTag} ===\n`);
+
+        for (const msg of messages) {
+            const status = msg.replied ? "REPLIED" : "UNREPLIED";
+            const time = formatRelativeTime(msg.timestamp);
+
+            console.log(`[${msg.id}] (${time}) - ${status}`);
+            console.log(`    "${truncate(msg.content, 150)}"`);
+            if (msg.attachments.length > 0) {
+                console.log(`    [${msg.attachments.length} attachment(s)]`);
+            }
+            console.log("");
+        }
+        return;
+    }
+
+    // Handle count subcommand
+    if (subcommand === "unread") {
+        const count = await yuno.dbCommands.getUnreadDmCount(yuno.database);
+        console.log(`You have ${count} unread DM(s).`);
+        return;
+    }
+
+    // Default: show inbox
+    const count = Math.min(Math.max(parseInt(args[0]) || 10, 1), 50);
+    const messages = await yuno.dbCommands.getInbox(yuno.database, count);
+
+    if (messages.length === 0) {
+        console.log("Your DM inbox is empty.");
+        return;
+    }
+
+    const unreadCount = await yuno.dbCommands.getUnreadDmCount(yuno.database);
+
+    console.log(`\n=== DM Inbox (${unreadCount} unread) ===\n`);
+
+    for (const msg of messages) {
+        const status = msg.replied ? "REPLIED" : "UNREPLIED";
+        const time = formatRelativeTime(msg.timestamp);
+        const marker = msg.replied ? " " : "*";
+
+        console.log(`${marker}[${msg.id}] ${msg.userTag} (${time}) - ${status}`);
+        console.log(`     "${truncate(msg.content, 120)}"`);
+        if (msg.attachments.length > 0) {
+            console.log(`     [${msg.attachments.length} attachment(s)]`);
+        }
+        console.log("");
+    }
+
+    console.log("---");
+    console.log("Use 'reply <id|user-id> <message>' to respond.");
+    console.log("Use 'inbox user <user-id>' to see DMs from a specific user.");
+    console.log("Use 'inbox <count>' to see more/fewer messages.");
+}
+
+module.exports.about = {
+    "command": "inbox",
+    "description": "View DM messages sent to the bot.",
+    "usage": "inbox [count] | inbox user <user-id> | inbox unread",
+    "examples": [
+        "inbox",
+        "inbox 20",
+        "inbox user 123456789012345678",
+        "inbox unread"
+    ],
+    "discord": false,
+    "terminal": true,
+    "list": false,
+    "listTerminal": true,
+    "aliases": ["dms", "dm-inbox"]
+}

--- a/src/commands/messages.js
+++ b/src/commands/messages.js
@@ -1,0 +1,160 @@
+/*
+    Yuno Gasai. A Discord.JS based bot, with multiple features.
+    Copyright (C) 2018 Maeeen <maeeennn@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see https://www.gnu.org/licenses/.
+*/
+
+const { ChannelType, PermissionsBitField } = require("discord.js");
+
+/**
+ * Find a channel across all guilds
+ */
+function findChannel(client, channelId) {
+    for (const guild of client.guilds.cache.values()) {
+        const channel = guild.channels.cache.get(channelId);
+        if (channel) return channel;
+    }
+    return null;
+}
+
+/**
+ * Format a message for display
+ */
+function formatMessage(msg) {
+    const time = msg.createdAt.toLocaleTimeString("en-US", {
+        hour: "2-digit",
+        minute: "2-digit",
+        hour12: false
+    });
+    const date = msg.createdAt.toLocaleDateString("en-US", {
+        month: "short",
+        day: "numeric"
+    });
+
+    const author = msg.author.tag;
+    const content = msg.content || "";
+
+    // Truncate long messages
+    const maxLen = 200;
+    const truncatedContent = content.length > maxLen
+        ? content.substring(0, maxLen) + "..."
+        : content;
+
+    // Handle attachments
+    const attachments = msg.attachments.size > 0
+        ? ` [${msg.attachments.size} attachment(s)]`
+        : "";
+
+    // Handle embeds
+    const embeds = msg.embeds.length > 0
+        ? ` [${msg.embeds.length} embed(s)]`
+        : "";
+
+    // Handle replies
+    const reply = msg.reference
+        ? " (reply)"
+        : "";
+
+    return `[${date} ${time}] ${author}${reply}: ${truncatedContent}${attachments}${embeds}`;
+}
+
+module.exports.runTerminal = async function(yuno, args) {
+    if (args.length < 1) {
+        console.log("Usage: messages <channel-id> [count]");
+        console.log("");
+        console.log("Fetches the last N messages from a channel (default: 20)");
+        console.log("");
+        console.log("Examples:");
+        console.log("  messages 123456789012345678");
+        console.log("  messages 123456789012345678 50");
+        return;
+    }
+
+    const channelId = args[0];
+    if (!/^\d{17,19}$/.test(channelId)) {
+        console.log("Error: Invalid channel ID format.");
+        return;
+    }
+
+    const count = Math.min(Math.max(parseInt(args[1]) || 20, 1), 100);
+
+    const channel = findChannel(yuno.dC, channelId);
+    if (!channel) {
+        console.log(`Error: Channel not found: ${channelId}`);
+        return;
+    }
+
+    // Check if it's a text-based channel
+    if (channel.type !== ChannelType.GuildText &&
+        channel.type !== ChannelType.GuildAnnouncement &&
+        channel.type !== ChannelType.PublicThread &&
+        channel.type !== ChannelType.PrivateThread &&
+        channel.type !== ChannelType.AnnouncementThread) {
+        console.log("Error: Cannot read messages from this channel type.");
+        return;
+    }
+
+    // Check permissions
+    const botMember = channel.guild.members.cache.get(yuno.dC.user.id);
+    if (!channel.permissionsFor(botMember)?.has(PermissionsBitField.Flags.ViewChannel)) {
+        console.log("Error: Bot does not have permission to view this channel.");
+        return;
+    }
+    if (!channel.permissionsFor(botMember)?.has(PermissionsBitField.Flags.ReadMessageHistory)) {
+        console.log("Error: Bot does not have permission to read message history.");
+        return;
+    }
+
+    console.log(`Fetching last ${count} messages from #${channel.name}...`);
+
+    try {
+        const messages = await channel.messages.fetch({ limit: count });
+
+        if (messages.size === 0) {
+            console.log("No messages found in this channel.");
+            return;
+        }
+
+        console.log(`\n=== #${channel.name} in ${channel.guild.name} ===\n`);
+
+        // Sort by timestamp (oldest first)
+        const sorted = [...messages.values()].sort((a, b) =>
+            a.createdTimestamp - b.createdTimestamp
+        );
+
+        for (const msg of sorted) {
+            console.log(formatMessage(msg));
+        }
+
+        console.log(`\n--- ${messages.size} message(s) ---`);
+    } catch (e) {
+        console.log(`Error fetching messages: ${e.message}`);
+    }
+}
+
+module.exports.about = {
+    "command": "messages",
+    "description": "Fetch message history from a Discord channel.",
+    "usage": "messages <channel-id> [count]",
+    "examples": [
+        "messages 123456789012345678",
+        "messages 123456789012345678 50"
+    ],
+    "discord": false,
+    "terminal": true,
+    "list": false,
+    "listTerminal": true,
+    "aliases": ["history", "msgs"]
+}

--- a/src/commands/reply.js
+++ b/src/commands/reply.js
@@ -1,0 +1,136 @@
+/*
+    Yuno Gasai. A Discord.JS based bot, with multiple features.
+    Copyright (C) 2018 Maeeen <maeeennn@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see https://www.gnu.org/licenses/.
+*/
+
+module.exports.runTerminal = async function(yuno, args, rawInput, rl) {
+    if (args.length < 1) {
+        console.log("Usage: reply <inbox-id|user-id> [message]");
+        console.log("");
+        console.log("Reply to a DM by inbox ID (small number) or user ID (17-19 digits).");
+        console.log("If message is not provided, you can type a multi-line message.");
+        console.log("");
+        console.log("Examples:");
+        console.log("  reply 1 Hello, thanks for your message!");
+        console.log("  reply 123456789012345678 Hi there!");
+        console.log("  reply 1");
+        return;
+    }
+
+    const target = args[0];
+    let userId;
+    let inboxId = null;
+
+    // Determine if target is inbox ID or user ID
+    if (/^\d{1,10}$/.test(target) && target.length < 15) {
+        // Small number = inbox ID
+        inboxId = parseInt(target);
+        const inboxMsg = await yuno.dbCommands.getInboxMessage(yuno.database, inboxId);
+
+        if (!inboxMsg) {
+            console.log(`Error: Inbox message #${inboxId} not found.`);
+            return;
+        }
+
+        userId = inboxMsg.usrId;
+    } else if (/^\d{17,19}$/.test(target)) {
+        // Long number = user ID
+        userId = target;
+    } else {
+        console.log("Error: Invalid ID format.");
+        console.log("Use a small number for inbox ID or a 17-19 digit Discord user ID.");
+        return;
+    }
+
+    // Get message content
+    let message = args.slice(1).join(" ");
+
+    // If no message provided, read multi-line input
+    if (!message && rl) {
+        console.log("Enter message (end with empty line or Ctrl+D):");
+        const lines = [];
+
+        const readLine = () => {
+            return new Promise((resolve) => {
+                rl.question("", (line) => {
+                    resolve(line);
+                });
+            });
+        };
+
+        while (true) {
+            try {
+                const line = await readLine();
+                if (line === "") {
+                    break;
+                }
+                lines.push(line);
+            } catch (e) {
+                break;
+            }
+        }
+
+        message = lines.join("\n");
+    }
+
+    if (!message) {
+        console.log("Error: No message provided.");
+        return;
+    }
+
+    // Try to send the DM
+    try {
+        const user = await yuno.dC.users.fetch(userId);
+
+        if (!user) {
+            console.log(`Error: User not found: ${userId}`);
+            return;
+        }
+
+        await user.send(message);
+
+        console.log(`Successfully sent DM to ${user.tag}`);
+
+        // Mark inbox message as replied if we have an inbox ID
+        if (inboxId) {
+            await yuno.dbCommands.markDmReplied(yuno.database, inboxId);
+            console.log(`Inbox message #${inboxId} marked as replied.`);
+        }
+
+    } catch (e) {
+        if (e.code === 50007) {
+            console.log("Error: Cannot send DM to this user (DMs disabled or bot blocked).");
+        } else {
+            console.log(`Error sending DM: ${e.message}`);
+        }
+    }
+}
+
+module.exports.about = {
+    "command": "reply",
+    "description": "Reply to a DM in the inbox.",
+    "usage": "reply <inbox-id|user-id> [message]",
+    "examples": [
+        "reply 1 Hello!",
+        "reply 123456789012345678 Hi there!",
+        "reply 1"
+    ],
+    "discord": false,
+    "terminal": true,
+    "list": false,
+    "listTerminal": true,
+    "aliases": ["dm", "respond"]
+}

--- a/src/commands/send.js
+++ b/src/commands/send.js
@@ -1,0 +1,130 @@
+/*
+    Yuno Gasai. A Discord.JS based bot, with multiple features.
+    Copyright (C) 2018 Maeeen <maeeennn@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see https://www.gnu.org/licenses/.
+*/
+
+const { ChannelType, PermissionsBitField } = require("discord.js");
+
+/**
+ * Find a channel across all guilds
+ */
+function findChannel(client, channelId) {
+    // Search all guilds for the channel
+    for (const guild of client.guilds.cache.values()) {
+        const channel = guild.channels.cache.get(channelId);
+        if (channel) return channel;
+    }
+    return null;
+}
+
+module.exports.runTerminal = async function(yuno, args, rawInput, rl) {
+    if (args.length < 1) {
+        console.log("Usage: send <channel-id> [message]");
+        console.log("");
+        console.log("If message is not provided, you can type a multi-line message.");
+        console.log("End with an empty line or Ctrl+D.");
+        console.log("");
+        console.log("Examples:");
+        console.log("  send 123456789012345678 Hello world!");
+        console.log("  send 123456789012345678");
+        return;
+    }
+
+    const channelId = args[0];
+    if (!/^\d{17,19}$/.test(channelId)) {
+        console.log("Error: Invalid channel ID format.");
+        return;
+    }
+
+    const channel = findChannel(yuno.dC, channelId);
+    if (!channel) {
+        console.log(`Error: Channel not found: ${channelId}`);
+        return;
+    }
+
+    // Check if it's a text-based channel
+    if (channel.type !== ChannelType.GuildText &&
+        channel.type !== ChannelType.GuildAnnouncement &&
+        channel.type !== ChannelType.PublicThread &&
+        channel.type !== ChannelType.PrivateThread) {
+        console.log("Error: Cannot send messages to this channel type.");
+        return;
+    }
+
+    // Check permissions
+    const botMember = channel.guild.members.cache.get(yuno.dC.user.id);
+    if (!channel.permissionsFor(botMember)?.has(PermissionsBitField.Flags.SendMessages)) {
+        console.log("Error: Bot does not have permission to send messages in this channel.");
+        return;
+    }
+
+    let message = args.slice(1).join(" ");
+
+    // If no message provided, read multi-line input
+    if (!message && rl) {
+        console.log("Enter message (end with empty line or Ctrl+D):");
+        const lines = [];
+
+        const readLine = () => {
+            return new Promise((resolve) => {
+                rl.question("", (line) => {
+                    resolve(line);
+                });
+            });
+        };
+
+        while (true) {
+            try {
+                const line = await readLine();
+                if (line === "") {
+                    break;
+                }
+                lines.push(line);
+            } catch (e) {
+                break;
+            }
+        }
+
+        message = lines.join("\n");
+    }
+
+    if (!message) {
+        console.log("Error: No message provided.");
+        return;
+    }
+
+    try {
+        await channel.send(message);
+        console.log(`Message sent to #${channel.name} in ${channel.guild.name}`);
+    } catch (e) {
+        console.log(`Error sending message: ${e.message}`);
+    }
+}
+
+module.exports.about = {
+    "command": "send",
+    "description": "Send a message to a Discord channel.",
+    "usage": "send <channel-id> [message]",
+    "examples": [
+        "send 123456789012345678 Hello!",
+        "send 123456789012345678"
+    ],
+    "discord": false,
+    "terminal": true,
+    "list": false,
+    "listTerminal": true,
+    "aliases": ["msg", "say"]
+}

--- a/src/commands/servers.js
+++ b/src/commands/servers.js
@@ -1,0 +1,107 @@
+/*
+    Yuno Gasai. A Discord.JS based bot, with multiple features.
+    Copyright (C) 2018 Maeeen <maeeennn@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see https://www.gnu.org/licenses/.
+*/
+
+const { PermissionsBitField } = require("discord.js");
+
+/**
+ * Get permission names from a permission bitfield
+ */
+function getKeyPermissions(permissions) {
+    const keyPerms = [
+        "Administrator",
+        "ManageGuild",
+        "ManageChannels",
+        "ManageRoles",
+        "ManageMessages",
+        "KickMembers",
+        "BanMembers",
+        "ModerateMembers"
+    ];
+
+    const hasPerms = [];
+    for (const perm of keyPerms) {
+        if (permissions.has(PermissionsBitField.Flags[perm])) {
+            hasPerms.push(perm);
+        }
+    }
+
+    return hasPerms.length > 0 ? hasPerms.join(", ") : "Basic permissions";
+}
+
+module.exports.runTerminal = async function(yuno, args) {
+    const verbose = args.includes("-v") || args.includes("--verbose");
+    const guilds = yuno.dC.guilds.cache;
+
+    if (guilds.size === 0) {
+        console.log("Bot is not in any servers.");
+        return;
+    }
+
+    console.log(`\n=== Servers (${guilds.size}) ===\n`);
+
+    let index = 1;
+    for (const [guildId, guild] of guilds) {
+        const owner = await guild.fetchOwner().catch(() => null);
+        const botMember = guild.members.cache.get(yuno.dC.user.id);
+        const permissions = botMember?.permissions;
+
+        // Count channel types
+        const textChannels = guild.channels.cache.filter(c => c.type === 0).size;
+        const voiceChannels = guild.channels.cache.filter(c => c.type === 2).size;
+        const categories = guild.channels.cache.filter(c => c.type === 4).size;
+        const totalChannels = guild.channels.cache.size;
+
+        console.log(`${index}. ${guild.name} [${guildId}]`);
+        console.log(`   Members: ${guild.memberCount} | Channels: ${totalChannels} | Roles: ${guild.roles.cache.size}`);
+
+        if (verbose) {
+            console.log(`   Channel breakdown: ${textChannels} text, ${voiceChannels} voice, ${categories} categories`);
+            console.log(`   Bot permissions: ${permissions ? getKeyPermissions(permissions) : "Unknown"}`);
+            console.log(`   Owner: ${owner?.user.tag || "Unknown"} (${guild.ownerId})`);
+            console.log(`   Created: ${guild.createdAt.toLocaleDateString()}`);
+
+            // Check bot-ban status
+            const banStatus = await yuno.dbCommands.getBotBan(yuno.database, guildId);
+            if (banStatus) {
+                console.log(`   [BOT-BANNED] Reason: ${banStatus.reason || "No reason"}`);
+            }
+        } else {
+            console.log(`   Bot perms: ${permissions ? getKeyPermissions(permissions) : "Unknown"}`);
+            console.log(`   Owner: ${owner?.user.tag || "Unknown"}`);
+        }
+
+        console.log("");
+        index++;
+    }
+
+    if (!verbose) {
+        console.log("Tip: Use 'servers -v' for more detailed information.");
+    }
+}
+
+module.exports.about = {
+    "command": "servers",
+    "description": "List all servers the bot is in with detailed information.",
+    "usage": "servers [-v|--verbose]",
+    "examples": ["servers", "servers -v"],
+    "discord": false,
+    "terminal": true,
+    "list": false,
+    "listTerminal": true,
+    "aliases": ["guilds", "serverlist"]
+}

--- a/src/commands/set-dm-channel.js
+++ b/src/commands/set-dm-channel.js
@@ -1,0 +1,99 @@
+/*
+    Yuno Gasai. A Discord.JS based bot, with multiple features.
+    Copyright (C) 2018 Maeeen <maeeennn@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see https://www.gnu.org/licenses/.
+*/
+
+const { ChannelType } = require("discord.js");
+
+module.exports.run = async function(yuno, author, args, msg) {
+    if (args.length < 1) {
+        return msg.channel.send(`:information_source: **DM Forwarding Setup**
+
+This command configures a channel where DMs sent to the bot will be forwarded.
+
+**Usage:**
+\`set-dm-channel <#channel>\` - Set the DM forwarding channel
+\`set-dm-channel none\` - Disable DM forwarding
+
+**Note:** If this is the master server (configured in config.json), ALL DMs will be forwarded here. Otherwise, only DMs from members of this server will be forwarded.`);
+    }
+
+    const input = args[0].toLowerCase();
+
+    // Handle "none" to disable
+    if (input === "none" || input === "off" || input === "disable") {
+        await yuno.dbCommands.removeDmConfig(yuno.database, msg.guild.id);
+        return msg.channel.send(":white_check_mark: DM forwarding has been disabled for this server.");
+    }
+
+    // Parse channel mention or ID
+    const channelMatch = args[0].match(/^<#(\d+)>$/) || args[0].match(/^(\d{17,19})$/);
+
+    if (!channelMatch) {
+        return msg.channel.send(":negative_squared_cross_mark: Please mention a channel or provide a valid channel ID.");
+    }
+
+    const channelId = channelMatch[1];
+    const channel = msg.guild.channels.cache.get(channelId);
+
+    if (!channel) {
+        return msg.channel.send(":negative_squared_cross_mark: Channel not found in this server.");
+    }
+
+    // Check if it's a text channel
+    if (channel.type !== ChannelType.GuildText && channel.type !== ChannelType.GuildAnnouncement) {
+        return msg.channel.send(":negative_squared_cross_mark: Please select a text channel.");
+    }
+
+    // Check if bot can send messages there
+    const botMember = msg.guild.members.cache.get(yuno.dC.user.id);
+    if (!channel.permissionsFor(botMember)?.has("SendMessages")) {
+        return msg.channel.send(":negative_squared_cross_mark: I don't have permission to send messages in that channel.");
+    }
+
+    // Save the configuration
+    await yuno.dbCommands.setDmConfig(yuno.database, msg.guild.id, channelId);
+
+    // Check if this is the master server
+    const masterServer = yuno.configManager.getValue("masterServer");
+    const isMaster = msg.guild.id === masterServer;
+
+    let response = `:white_check_mark: DM forwarding channel set to <#${channelId}>.\n\n`;
+
+    if (isMaster) {
+        response += ":star: **This is the master server.** ALL DMs sent to the bot will be forwarded here.";
+    } else {
+        response += "DMs from members of this server will be forwarded here.";
+    }
+
+    msg.channel.send(response);
+}
+
+module.exports.about = {
+    "command": "set-dm-channel",
+    "description": "Configure the channel where DMs to the bot are forwarded.",
+    "usage": "set-dm-channel <#channel|none>",
+    "examples": [
+        "set-dm-channel #bot-dms",
+        "set-dm-channel none"
+    ],
+    "discord": true,
+    "terminal": false,
+    "list": true,
+    "listTerminal": false,
+    "onlyMasterUsers": true,
+    "aliases": ["dmchannel", "dm-channel"]
+}

--- a/src/commands/tban.js
+++ b/src/commands/tban.js
@@ -1,0 +1,117 @@
+/*
+    Yuno Gasai. A Discord.JS based bot, with multiple features.
+    Copyright (C) 2018 Maeeen <maeeennn@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see https://www.gnu.org/licenses/.
+*/
+
+module.exports.runTerminal = async function(yuno, args) {
+    if (args.length < 2) {
+        console.log("Usage: tban <server-id> <user-id> [reason]");
+        console.log("");
+        console.log("Ban a user from a server via terminal.");
+        console.log("");
+        console.log("Examples:");
+        console.log("  tban 123456789012345678 987654321098765432");
+        console.log("  tban 123456789012345678 987654321098765432 Spamming");
+        return;
+    }
+
+    const serverId = args[0];
+    const userId = args[1];
+    const reason = args.slice(2).join(" ") || "Terminal ban";
+
+    if (!/^\d{17,19}$/.test(serverId)) {
+        console.log("Error: Invalid server ID format.");
+        return;
+    }
+
+    if (!/^\d{17,19}$/.test(userId)) {
+        console.log("Error: Invalid user ID format.");
+        return;
+    }
+
+    const guild = yuno.dC.guilds.cache.get(serverId);
+    if (!guild) {
+        console.log(`Error: Server not found: ${serverId}`);
+        console.log("Use 'servers' command to see available servers.");
+        return;
+    }
+
+    // Check if bot has ban permission
+    const botMember = guild.members.cache.get(yuno.dC.user.id);
+    if (!botMember?.permissions.has("BanMembers")) {
+        console.log("Error: Bot does not have ban permission in this server.");
+        return;
+    }
+
+    // Try to get user info
+    let userTag = userId;
+    try {
+        const user = await yuno.dC.users.fetch(userId);
+        userTag = user.tag;
+    } catch (e) {
+        // User not found, proceed anyway
+    }
+
+    // Check if already banned
+    try {
+        const existingBan = await guild.bans.fetch(userId);
+        if (existingBan) {
+            console.log(`User ${userTag} is already banned from ${guild.name}.`);
+            console.log(`Reason: ${existingBan.reason || "No reason"}`);
+            return;
+        }
+    } catch (e) {
+        // Not banned, continue
+    }
+
+    try {
+        await guild.members.ban(userId, {
+            reason: `[Terminal] ${reason}`,
+            deleteMessageSeconds: 0
+        });
+
+        console.log(`Successfully banned ${userTag} from ${guild.name}`);
+        console.log(`Reason: ${reason}`);
+
+        // Log to mod actions
+        await yuno.dbCommands.addModAction(
+            yuno.database,
+            serverId,
+            "terminal",
+            userId,
+            "ban",
+            reason,
+            Date.now()
+        );
+    } catch (e) {
+        console.log(`Error banning user: ${e.message}`);
+    }
+}
+
+module.exports.about = {
+    "command": "tban",
+    "description": "Ban a user from a server via terminal.",
+    "usage": "tban <server-id> <user-id> [reason]",
+    "examples": [
+        "tban 123456789012345678 987654321098765432",
+        "tban 123456789012345678 987654321098765432 Spamming"
+    ],
+    "discord": false,
+    "terminal": true,
+    "list": false,
+    "listTerminal": true,
+    "aliases": ["termban", "terminalban"]
+}

--- a/src/commands/texportbans.js
+++ b/src/commands/texportbans.js
@@ -1,0 +1,126 @@
+/*
+    Yuno Gasai. A Discord.JS based bot, with multiple features.
+    Copyright (C) 2018 Maeeen <maeeennn@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see https://www.gnu.org/licenses/.
+*/
+
+const fs = require("fs").promises;
+const path = require("path");
+
+module.exports.runTerminal = async function(yuno, args) {
+    if (args.length < 1) {
+        console.log("Usage: texportbans <server-id> [output-file]");
+        console.log("");
+        console.log("Export all bans from a server to a JSON file.");
+        console.log("Default output: ./BANS-<server-id>.txt");
+        console.log("");
+        console.log("Examples:");
+        console.log("  texportbans 123456789012345678");
+        console.log("  texportbans 123456789012345678 ./my-bans.json");
+        return;
+    }
+
+    const serverId = args[0];
+    if (!/^\d{17,19}$/.test(serverId)) {
+        console.log("Error: Invalid server ID format.");
+        return;
+    }
+
+    const guild = yuno.dC.guilds.cache.get(serverId);
+    if (!guild) {
+        console.log(`Error: Server not found: ${serverId}`);
+        console.log("Use 'servers' command to see available servers.");
+        return;
+    }
+
+    // Check bot permissions
+    const botMember = guild.members.cache.get(yuno.dC.user.id);
+    if (!botMember?.permissions.has("BanMembers")) {
+        console.log("Error: Bot does not have ban permission in this server.");
+        return;
+    }
+
+    // Determine output file
+    let outputFile = args[1] || `./BANS-${serverId}.txt`;
+
+    // Validate output path (prevent path traversal to sensitive areas)
+    const resolvedPath = path.resolve(outputFile);
+    if (resolvedPath.includes("..")) {
+        console.log("Error: Invalid file path.");
+        return;
+    }
+
+    console.log(`Exporting bans from ${guild.name}...`);
+
+    try {
+        const allBannedUserIds = [];
+        let lastBanId = null;
+        let totalFetched = 0;
+        const batchSize = 1000;
+
+        while (true) {
+            const fetchOptions = { limit: batchSize };
+            if (lastBanId) {
+                fetchOptions.after = lastBanId;
+            }
+
+            const bans = await guild.bans.fetch(fetchOptions);
+
+            if (bans.size === 0) {
+                break;
+            }
+
+            const batchUserIds = Array.from(bans.values()).map(ban => ban.user.id);
+            allBannedUserIds.push(...batchUserIds);
+            totalFetched += bans.size;
+
+            // Progress update
+            if (totalFetched % 5000 === 0) {
+                console.log(`  Fetched ${totalFetched} bans...`);
+            }
+
+            lastBanId = batchUserIds[batchUserIds.length - 1];
+
+            if (bans.size < batchSize) {
+                break;
+            }
+        }
+
+        console.log(`Fetched ${allBannedUserIds.length} total bans.`);
+
+        // Write to file
+        const banstr = JSON.stringify(allBannedUserIds);
+        await fs.writeFile(outputFile, banstr);
+
+        console.log(`Successfully exported ${allBannedUserIds.length} bans to ${outputFile}`);
+    } catch (e) {
+        console.log(`Error exporting bans: ${e.message}`);
+    }
+}
+
+module.exports.about = {
+    "command": "texportbans",
+    "description": "Export bans from a server to a file via terminal.",
+    "usage": "texportbans <server-id> [output-file]",
+    "examples": [
+        "texportbans 123456789012345678",
+        "texportbans 123456789012345678 ./my-bans.json"
+    ],
+    "discord": false,
+    "terminal": true,
+    "list": false,
+    "listTerminal": true,
+    "aliases": ["tebans", "termexportbans"]
+}

--- a/src/commands/timportbans.js
+++ b/src/commands/timportbans.js
@@ -1,0 +1,151 @@
+/*
+    Yuno Gasai. A Discord.JS based bot, with multiple features.
+    Copyright (C) 2018 Maeeen <maeeennn@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see https://www.gnu.org/licenses/.
+*/
+
+const fs = require("fs").promises;
+const path = require("path");
+
+module.exports.runTerminal = async function(yuno, args) {
+    if (args.length < 2) {
+        console.log("Usage: timportbans <server-id> <file-path>");
+        console.log("");
+        console.log("Import bans from a JSON file to a server.");
+        console.log("File should contain an array of user IDs: [\"id1\", \"id2\", ...]");
+        console.log("");
+        console.log("Examples:");
+        console.log("  timportbans 123456789012345678 ./BANS-123456789012345678.txt");
+        console.log("  timportbans 123456789012345678 ./my-bans.json");
+        return;
+    }
+
+    const serverId = args[0];
+    const filePath = args[1];
+
+    if (!/^\d{17,19}$/.test(serverId)) {
+        console.log("Error: Invalid server ID format.");
+        return;
+    }
+
+    const guild = yuno.dC.guilds.cache.get(serverId);
+    if (!guild) {
+        console.log(`Error: Server not found: ${serverId}`);
+        console.log("Use 'servers' command to see available servers.");
+        return;
+    }
+
+    // Check bot permissions
+    const botMember = guild.members.cache.get(yuno.dC.user.id);
+    if (!botMember?.permissions.has("BanMembers")) {
+        console.log("Error: Bot does not have ban permission in this server.");
+        return;
+    }
+
+    // Validate file path
+    const resolvedPath = path.resolve(filePath);
+
+    // Read ban list
+    let data;
+    try {
+        data = await fs.readFile(resolvedPath, "utf8");
+    } catch (err) {
+        console.log(`Error reading file: ${err.code || err.message}`);
+        return;
+    }
+
+    let bans;
+    try {
+        bans = JSON.parse(data);
+
+        if (!Array.isArray(bans) || bans.length === 0) {
+            console.log("Error: File must contain a JSON array of user IDs.");
+            return;
+        }
+    } catch (e) {
+        console.log("Error: Invalid JSON format.");
+        return;
+    }
+
+    console.log(`Importing ${bans.length} bans to ${guild.name}...`);
+    console.log("This may take a while due to rate limits.");
+    console.log("");
+
+    // Process in batches
+    const batchSize = 5;
+    const delayBetweenBans = 1000;
+    const delayBetweenBatches = 5000;
+
+    let totalBanned = 0;
+    let totalFailed = 0;
+    let totalAlreadyBanned = 0;
+    let processedCount = 0;
+    const totalBatches = Math.ceil(bans.length / batchSize);
+
+    for (let i = 0; i < bans.length; i += batchSize) {
+        const batch = bans.slice(i, i + batchSize);
+        const batchNum = Math.floor(i / batchSize) + 1;
+
+        // Update status
+        process.stdout.write(`\rProcessing batch ${batchNum}/${totalBatches} - ${processedCount}/${bans.length} (${Math.round((processedCount/bans.length)*100)}%)`);
+
+        for (const userId of batch) {
+            try {
+                await guild.members.ban(userId, {
+                    deleteMessageSeconds: 0,
+                    reason: "Terminal ban import"
+                });
+                totalBanned++;
+            } catch (error) {
+                if (error.code === 10026 || error.message.includes("already banned")) {
+                    totalAlreadyBanned++;
+                } else {
+                    totalFailed++;
+                }
+            }
+
+            processedCount++;
+
+            if (processedCount < bans.length) {
+                await new Promise(resolve => setTimeout(resolve, delayBetweenBans));
+            }
+        }
+
+        if (i + batchSize < bans.length) {
+            await new Promise(resolve => setTimeout(resolve, delayBetweenBatches));
+        }
+    }
+
+    console.log("\n\n=== Import Complete ===");
+    console.log(`Successfully banned: ${totalBanned}`);
+    console.log(`Already banned: ${totalAlreadyBanned}`);
+    console.log(`Failed: ${totalFailed}`);
+    console.log(`Total processed: ${bans.length}`);
+}
+
+module.exports.about = {
+    "command": "timportbans",
+    "description": "Import bans from a file to a server via terminal.",
+    "usage": "timportbans <server-id> <file-path>",
+    "examples": [
+        "timportbans 123456789012345678 ./BANS-123456789012345678.txt",
+        "timportbans 123456789012345678 ./my-bans.json"
+    ],
+    "discord": false,
+    "terminal": true,
+    "list": false,
+    "listTerminal": true,
+    "aliases": ["tibans", "termimportbans"]
+}

--- a/src/commands/watch.js
+++ b/src/commands/watch.js
@@ -1,0 +1,205 @@
+/*
+    Yuno Gasai. A Discord.JS based bot, with multiple features.
+    Copyright (C) 2018 Maeeen <maeeennn@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see https://www.gnu.org/licenses/.
+*/
+
+const { ChannelType, PermissionsBitField } = require("discord.js");
+
+// Track active watch sessions
+const activeWatches = new Map();
+
+/**
+ * Find a channel across all guilds
+ */
+function findChannel(client, channelId) {
+    for (const guild of client.guilds.cache.values()) {
+        const channel = guild.channels.cache.get(channelId);
+        if (channel) return channel;
+    }
+    return null;
+}
+
+/**
+ * Format a message for real-time display
+ */
+function formatMessage(msg) {
+    const time = new Date().toLocaleTimeString("en-US", {
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+        hour12: false
+    });
+
+    const author = msg.author.tag;
+    const content = msg.content || "";
+
+    // Truncate long messages
+    const maxLen = 150;
+    const truncatedContent = content.length > maxLen
+        ? content.substring(0, maxLen) + "..."
+        : content;
+
+    // Handle attachments
+    const attachments = msg.attachments.size > 0
+        ? ` [${msg.attachments.size} file(s)]`
+        : "";
+
+    // Handle embeds
+    const embeds = msg.embeds.length > 0
+        ? ` [embed]`
+        : "";
+
+    return `[${time}] ${author}: ${truncatedContent}${attachments}${embeds}`;
+}
+
+module.exports.runTerminal = async function(yuno, args, rawInput, rl) {
+    if (args.length < 1) {
+        // Show status if no args
+        if (activeWatches.size > 0) {
+            console.log("\n=== Active Watches ===\n");
+            for (const [channelId, info] of activeWatches) {
+                console.log(`#${info.channelName} [${channelId}] in ${info.guildName}`);
+            }
+            console.log("\nUse 'watch stop <channel-id>' to stop watching.");
+            console.log("Use 'watch stop all' to stop all watches.");
+        } else {
+            console.log("Usage: watch <channel-id>");
+            console.log("       watch stop <channel-id|all>");
+            console.log("");
+            console.log("Start real-time message streaming from a channel.");
+            console.log("Messages will appear as they are sent.");
+            console.log("");
+            console.log("Examples:");
+            console.log("  watch 123456789012345678");
+            console.log("  watch stop 123456789012345678");
+            console.log("  watch stop all");
+        }
+        return;
+    }
+
+    // Handle stop command
+    if (args[0].toLowerCase() === "stop") {
+        const target = args[1];
+
+        if (!target) {
+            console.log("Usage: watch stop <channel-id|all>");
+            return;
+        }
+
+        if (target.toLowerCase() === "all") {
+            const count = activeWatches.size;
+            for (const [channelId, info] of activeWatches) {
+                yuno.dC.removeListener("messageCreate", info.handler);
+            }
+            activeWatches.clear();
+            console.log(`Stopped watching ${count} channel(s).`);
+            return;
+        }
+
+        const watchInfo = activeWatches.get(target);
+        if (!watchInfo) {
+            console.log(`Not watching channel: ${target}`);
+            return;
+        }
+
+        yuno.dC.removeListener("messageCreate", watchInfo.handler);
+        activeWatches.delete(target);
+        console.log(`Stopped watching #${watchInfo.channelName}`);
+        return;
+    }
+
+    const channelId = args[0];
+    if (!/^\d{17,19}$/.test(channelId)) {
+        console.log("Error: Invalid channel ID format.");
+        return;
+    }
+
+    // Check if already watching
+    if (activeWatches.has(channelId)) {
+        console.log("Already watching this channel.");
+        console.log("Use 'watch stop " + channelId + "' to stop.");
+        return;
+    }
+
+    const channel = findChannel(yuno.dC, channelId);
+    if (!channel) {
+        console.log(`Error: Channel not found: ${channelId}`);
+        return;
+    }
+
+    // Check if it's a text-based channel
+    if (channel.type !== ChannelType.GuildText &&
+        channel.type !== ChannelType.GuildAnnouncement &&
+        channel.type !== ChannelType.PublicThread &&
+        channel.type !== ChannelType.PrivateThread &&
+        channel.type !== ChannelType.AnnouncementThread) {
+        console.log("Error: Cannot watch this channel type.");
+        return;
+    }
+
+    // Check permissions
+    const botMember = channel.guild.members.cache.get(yuno.dC.user.id);
+    if (!channel.permissionsFor(botMember)?.has(PermissionsBitField.Flags.ViewChannel)) {
+        console.log("Error: Bot does not have permission to view this channel.");
+        return;
+    }
+
+    // Create message handler
+    const handler = (message) => {
+        if (message.channel.id === channelId) {
+            console.log(formatMessage(message));
+        }
+    };
+
+    // Register handler
+    yuno.dC.on("messageCreate", handler);
+
+    // Store watch info
+    activeWatches.set(channelId, {
+        handler,
+        channelName: channel.name,
+        guildName: channel.guild.name,
+        startTime: Date.now()
+    });
+
+    console.log(`\n=== Now watching #${channel.name} in ${channel.guild.name} ===`);
+    console.log(`Messages will appear in real-time.`);
+    console.log(`Use 'watch stop ${channelId}' to stop watching.\n`);
+}
+
+// Cleanup function for module shutdown
+module.exports.cleanup = function(yuno) {
+    for (const [channelId, info] of activeWatches) {
+        yuno.dC.removeListener("messageCreate", info.handler);
+    }
+    activeWatches.clear();
+}
+
+module.exports.about = {
+    "command": "watch",
+    "description": "Real-time message streaming from a Discord channel.",
+    "usage": "watch <channel-id> | watch stop <channel-id|all>",
+    "examples": [
+        "watch 123456789012345678",
+        "watch stop 123456789012345678",
+        "watch stop all"
+    ],
+    "discord": false,
+    "terminal": true,
+    "list": false,
+    "listTerminal": true,
+    "aliases": ["stream", "listen"]
+}

--- a/src/modules/command-executor.js
+++ b/src/modules/command-executor.js
@@ -28,9 +28,25 @@ let workOnlyOnGuild = null,
 
 module.exports.modulename = "command-executor";
 
-let msgEvent = (function(msg) {
+let msgEvent = (async function(msg) {
     if (msg.author.id === discClient.user.id)
         return;
+
+    // Check if user or server is bot-banned
+    try {
+        const banStatus = await Yuno.dbCommands.isBotBanned(
+            Yuno.database,
+            msg.author.id,
+            msg.guild?.id || null
+        );
+
+        if (banStatus.banned) {
+            // Silently ignore messages from banned users/servers
+            return;
+        }
+    } catch (e) {
+        // If ban check fails, continue processing (fail open for commands)
+    }
 
     // if message sent in DM
     if (!msg.guild) {

--- a/src/modules/dm-handler.js
+++ b/src/modules/dm-handler.js
@@ -1,0 +1,246 @@
+/*
+    Yuno Gasai. A Discord.JS based bot, with multiple features.
+    Copyright (C) 2018 Maeeen <maeeennn@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see https://www.gnu.org/licenses/.
+*/
+
+module.exports.modulename = "dm-handler";
+
+const { EmbedBuilder } = require("discord.js");
+
+let DISCORD_EVENTED = false,
+    discClient = null,
+    yunoInstance = null,
+    messageHandler = null;
+
+// Rate limit tracking for DM forwarding
+const rateLimitState = new Map();
+
+/**
+ * Format timestamp for display
+ */
+function formatTime(timestamp) {
+    const date = new Date(timestamp);
+    return date.toLocaleString();
+}
+
+/**
+ * Truncate content if too long
+ */
+function truncate(str, maxLen = 1024) {
+    if (!str) return "";
+    if (str.length <= maxLen) return str;
+    return str.substring(0, maxLen - 3) + "...";
+}
+
+/**
+ * Create embed for forwarded DM
+ * @param {User} user - The user who sent the DM
+ * @param {Message} message - The DM message
+ * @param {number} inboxId - The inbox ID
+ * @param {boolean} isMasterServer - Whether this is being sent to the master server
+ * @param {Guild} sourceGuild - The guild context (for non-master servers)
+ */
+function createDmEmbed(user, message, inboxId, isMasterServer = false, sourceGuild = null) {
+    const embed = new EmbedBuilder()
+        .setAuthor({
+            name: user.tag,
+            iconURL: user.displayAvatarURL({ size: 64 })
+        })
+        .setDescription(truncate(message.content) || "*No text content*")
+        .setColor(0x5865F2)
+        .setTimestamp();
+
+    // Footer shows different info based on context
+    let footerText = `User ID: ${user.id} | Inbox #${inboxId}`;
+    if (isMasterServer) {
+        footerText += " | Master Server";
+    } else if (sourceGuild) {
+        footerText += ` | Member of: ${sourceGuild.name}`;
+    }
+    embed.setFooter({ text: footerText });
+
+    // Add attachments field if present
+    if (message.attachments.size > 0) {
+        const attachmentList = message.attachments
+            .map(a => `[${a.name}](${a.url})`)
+            .join("\n");
+        embed.addFields({
+            name: "Attachments",
+            value: truncate(attachmentList, 1024)
+        });
+
+        // Set first image as thumbnail if it's an image
+        const firstImage = message.attachments.find(a =>
+            a.contentType?.startsWith("image/")
+        );
+        if (firstImage) {
+            embed.setThumbnail(firstImage.url);
+        }
+    }
+
+    return embed;
+}
+
+/**
+ * Forward a DM to a channel
+ * @param {TextChannel} channel - The channel to forward to
+ * @param {User} user - The user who sent the DM
+ * @param {Message} message - The DM message
+ * @param {number} inboxId - The inbox ID
+ * @param {boolean} isMasterServer - Whether this is the master server
+ * @param {Guild} sourceGuild - The guild context (for non-master servers)
+ */
+async function forwardToChannel(channel, user, message, inboxId, isMasterServer = false, sourceGuild = null) {
+    // Check rate limit
+    const rateLimit = rateLimitState.get(channel.id);
+    if (rateLimit && Date.now() < rateLimit.retryAfter) {
+        return false;
+    }
+
+    try {
+        const embed = createDmEmbed(user, message, inboxId, isMasterServer, sourceGuild);
+        await channel.send({ embeds: [embed] });
+        rateLimitState.delete(channel.id);
+        return true;
+    } catch (e) {
+        if (e.status === 429 || e.code === 429 || e.message?.includes("rate limit")) {
+            const retryAfter = e.retryAfter || e.retry_after || 10000;
+            rateLimitState.set(channel.id, {
+                retryAfter: Date.now() + retryAfter
+            });
+        }
+        return false;
+    }
+}
+
+/**
+ * Handle incoming DM
+ */
+async function onMessage(message) {
+    // Ignore messages from guilds (only handle DMs)
+    if (message.guild) return;
+
+    // Ignore messages from bots
+    if (message.author.bot) return;
+
+    const user = message.author;
+
+    try {
+        // Check if user is bot-banned
+        const banStatus = await yunoInstance.dbCommands.isBotBanned(
+            yunoInstance.database,
+            user.id,
+            null
+        );
+
+        if (banStatus.banned) {
+            // Silently ignore DMs from banned users
+            return;
+        }
+
+        // Save to inbox
+        const attachments = message.attachments.map(a => a.url);
+        const inboxId = await yunoInstance.dbCommands.saveDm(
+            yunoInstance.database,
+            user.id,
+            user.tag,
+            message.content,
+            attachments
+        );
+
+        // Get master server ID from config
+        const masterServer = yunoInstance.configManager.getValue("masterServer");
+
+        // Get all DM configs
+        const dmConfigs = await yunoInstance.dbCommands.getAllDmConfigs(yunoInstance.database);
+
+        // Forward to configured channels
+        for (const config of dmConfigs) {
+            const guild = discClient.guilds.cache.get(config.guildId);
+            if (!guild) continue;
+
+            const channel = guild.channels.cache.get(config.channelId);
+            if (!channel) continue;
+
+            // Check if this is master server (receives ALL DMs)
+            const isMasterServer = config.guildId === masterServer;
+
+            if (isMasterServer) {
+                // Master server receives ALL DMs from anyone
+                await forwardToChannel(channel, user, message, inboxId, true, null);
+            } else {
+                // Other servers only receive DMs from their own members
+                const member = guild.members.cache.get(user.id);
+                if (member) {
+                    await forwardToChannel(channel, user, message, inboxId, false, guild);
+                }
+            }
+        }
+
+        // Log to terminal
+        yunoInstance.prompt.info(`[DM] ${user.tag} (${user.id}): ${truncate(message.content, 100)}`);
+
+    } catch (e) {
+        yunoInstance.prompt.error(`[DM Handler] Error processing DM: ${e.message}`);
+    }
+}
+
+let discordConnected = async function(Yuno) {
+    discClient = Yuno.dC;
+    yunoInstance = Yuno;
+
+    if (!DISCORD_EVENTED) {
+        messageHandler = onMessage;
+        discClient.on("messageCreate", messageHandler);
+    }
+
+    DISCORD_EVENTED = true;
+
+    // Clean up old DMs periodically (every 24 hours)
+    setInterval(async () => {
+        try {
+            const deleted = await yunoInstance.dbCommands.clearOldDms(
+                yunoInstance.database,
+                30 // Keep DMs for 30 days
+            );
+            if (deleted > 0) {
+                yunoInstance.prompt.info(`[DM Handler] Cleaned up ${deleted} old DM(s)`);
+            }
+        } catch (e) {
+            // Ignore cleanup errors
+        }
+    }, 24 * 60 * 60 * 1000);
+};
+
+module.exports.init = function(Yuno, hotReloaded) {
+    if (hotReloaded)
+        discordConnected(Yuno);
+    else
+        Yuno.on("discord-connected", discordConnected);
+};
+
+module.exports.configLoaded = function() {};
+
+module.exports.beforeShutdown = async function(Yuno) {
+    rateLimitState.clear();
+
+    if (discClient && messageHandler) {
+        discClient.removeListener("messageCreate", messageHandler);
+    }
+
+    DISCORD_EVENTED = false;
+    messageHandler = null;
+};


### PR DESCRIPTION
## Summary

- **Terminal Commands**: New terminal-only commands for comprehensive server management
- **DM Inbox System**: Store and forward DMs sent to the bot with master/regular server distinction  
- **Bot-Level Bans**: Ban users or entire servers from using the bot (separate from Discord bans)

## New Features

### Terminal Commands
| Command | Description |
|---------|-------------|
| `servers` | List all servers with detailed info |
| `channels` | List channels with hierarchy and permissions |
| `send` | Send messages to any channel |
| `messages` | Fetch message history |
| `watch` | Real-time message streaming |
| `inbox` | View DMs sent to bot |
| `reply` | Reply to DMs |
| `tban` | Ban users from terminal |
| `texportbans` | Export bans to file |
| `timportbans` | Import bans from file |

### Discord Commands
| Command | Description |
|---------|-------------|
| `bot-ban` | Ban user/server from using the bot |
| `bot-unban` | Remove bot-level ban |
| `bot-banlist` | View all bot bans |
| `set-dm-channel` | Configure DM forwarding channel |
| `dm-status` | View DM forwarding configuration |

### DM Forwarding Logic
- **Master Server** (configured in config.json): Receives ALL DMs from anyone
- **Regular Servers**: Only receive DMs from their own members

## Database Changes
- `botBans` table - Stores bot-level user/server bans (separate from Discord bans)
- `dmConfig` table - Per-guild DM forwarding settings
- `dmInbox` table - Stores DMs sent to the bot for inbox viewing

## Test Plan
- [ ] Test terminal commands (servers, channels, send, messages, watch)
- [ ] Test DM forwarding to master server
- [ ] Test DM forwarding to regular servers (member-only)
- [ ] Test bot-ban functionality from Discord and terminal
- [ ] Test inbox viewing and reply functionality
- [ ] Test ban import/export from terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)