### PR TITLE
Implement full set-presence command

### DIFF
--- a/README.md
+++ b/README.md
@@ -518,6 +518,7 @@ timportbans <server-id> ./BANS-123456.txt
 | `scold` | *"Bad! But I still love you..."* 💢 |
 | `8ball` | *"Let fate decide~"* 🎱 |
 | `neko` | *"Nya~"* 🐱 |
+| `set-presence` | *"Let me show you how I'm feeling~"* 🎭 |
 | `db-encrypt` | *"Your secrets are mine to keep~"* 🔐 |
 | `set-logchannel` | *"I'll watch over everything~"* 📋 |
 | `log-status` | *"Here's what I'm watching~"* 👁️ |
@@ -542,6 +543,7 @@ timportbans <server-id> ./BANS-123456.txt
 | `tban` | *"Eliminating threats~"* 🔪 |
 | `texportbans` | *"Saving my enemies list~"* 📤 |
 | `timportbans` | *"Loading my enemies~"* 📥 |
+| `set-presence` | *"Changing my mood~"* 🎭 |
 
 *Use the `list` command to see all available commands!*
 

--- a/src/commands/set-presence.js
+++ b/src/commands/set-presence.js
@@ -16,11 +16,264 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
-module.exports.run = async function(yuno, author, args, msg) {
+const { ActivityType } = require("discord.js");
 
+// Map string types to ActivityType enum
+const ACTIVITY_TYPES = {
+    "playing": ActivityType.Playing,
+    "streaming": ActivityType.Streaming,
+    "listening": ActivityType.Listening,
+    "watching": ActivityType.Watching,
+    "competing": ActivityType.Competing,
+    "custom": ActivityType.Custom
+};
+
+const STATUS_OPTIONS = ["online", "idle", "dnd", "invisible"];
+
+module.exports.run = async function(yuno, author, args, msg) {
+    if (args.length < 1) {
+        return msg.channel.send(`:information_source: **Set Presence Command**
+
+*"Let me show you how I'm feeling~"* 💕
+
+**Usage:**
+\`set-presence <type> <text>\` - Set activity with text
+\`set-presence status <status>\` - Set online status
+\`set-presence clear\` - Clear current activity
+
+**Activity Types:**
+• \`playing\` - Playing <text>
+• \`watching\` - Watching <text>
+• \`listening\` - Listening to <text>
+• \`streaming\` - Streaming <text> (requires URL)
+• \`competing\` - Competing in <text>
+
+**Status Options:**
+• \`online\` - Green dot
+• \`idle\` - Yellow dot
+• \`dnd\` - Red dot (Do Not Disturb)
+• \`invisible\` - Appear offline
+
+**Examples:**
+\`set-presence playing with Yukki's heart\`
+\`set-presence watching over my senpai\`
+\`set-presence listening to Future Diary OST\`
+\`set-presence streaming Yuno Gasai https://twitch.tv/example\`
+\`set-presence status dnd\`
+\`set-presence clear\``);
+    }
+
+    const subcommand = args[0].toLowerCase();
+
+    // Handle clear
+    if (subcommand === "clear" || subcommand === "reset" || subcommand === "none") {
+        try {
+            await yuno.dC.user.setPresence({
+                activities: [],
+                status: "online"
+            });
+            return msg.channel.send(":white_check_mark: Presence cleared~");
+        } catch (e) {
+            return msg.channel.send(`:negative_squared_cross_mark: Failed to clear presence: ${e.message}`);
+        }
+    }
+
+    // Handle status change
+    if (subcommand === "status") {
+        const status = args[1]?.toLowerCase();
+
+        if (!status || !STATUS_OPTIONS.includes(status)) {
+            return msg.channel.send(`:negative_squared_cross_mark: Invalid status. Options: \`${STATUS_OPTIONS.join("`, `")}\``);
+        }
+
+        try {
+            await yuno.dC.user.setPresence({ status });
+            const statusEmoji = {
+                "online": ":green_circle:",
+                "idle": ":yellow_circle:",
+                "dnd": ":red_circle:",
+                "invisible": ":white_circle:"
+            };
+            return msg.channel.send(`${statusEmoji[status]} Status set to **${status}**~`);
+        } catch (e) {
+            return msg.channel.send(`:negative_squared_cross_mark: Failed to set status: ${e.message}`);
+        }
+    }
+
+    // Handle activity type
+    const activityType = ACTIVITY_TYPES[subcommand];
+
+    if (activityType === undefined) {
+        return msg.channel.send(`:negative_squared_cross_mark: Unknown type: \`${subcommand}\`
+Valid types: \`${Object.keys(ACTIVITY_TYPES).join("`, `")}\``);
+    }
+
+    // Get the activity text
+    let activityText = args.slice(1).join(" ");
+    let streamUrl = null;
+
+    // For streaming, check for URL
+    if (activityType === ActivityType.Streaming) {
+        const urlMatch = activityText.match(/(https?:\/\/[^\s]+)/);
+        if (urlMatch) {
+            streamUrl = urlMatch[1];
+            activityText = activityText.replace(streamUrl, "").trim();
+        }
+
+        if (!streamUrl) {
+            return msg.channel.send(`:negative_squared_cross_mark: Streaming requires a URL!
+Example: \`set-presence streaming My Stream https://twitch.tv/example\``);
+        }
+    }
+
+    if (!activityText) {
+        return msg.channel.send(":negative_squared_cross_mark: Please provide activity text!");
+    }
+
+    try {
+        const activity = {
+            name: activityText,
+            type: activityType
+        };
+
+        if (streamUrl) {
+            activity.url = streamUrl;
+        }
+
+        await yuno.dC.user.setPresence({
+            activities: [activity]
+        });
+
+        const typeDisplay = subcommand.charAt(0).toUpperCase() + subcommand.slice(1);
+        msg.channel.send(`:white_check_mark: Now **${typeDisplay}** ${activityText}${streamUrl ? ` (${streamUrl})` : ""}~`);
+    } catch (e) {
+        msg.channel.send(`:negative_squared_cross_mark: Failed to set presence: ${e.message}`);
+    }
+}
+
+module.exports.runTerminal = async function(yuno, args) {
+    if (args.length < 1) {
+        console.log("Set Presence Command");
+        console.log("");
+        console.log("Usage:");
+        console.log("  set-presence <type> <text>     - Set activity");
+        console.log("  set-presence status <status>   - Set online status");
+        console.log("  set-presence clear             - Clear activity");
+        console.log("");
+        console.log("Activity Types:");
+        console.log("  playing, watching, listening, streaming, competing");
+        console.log("");
+        console.log("Status Options:");
+        console.log("  online, idle, dnd, invisible");
+        console.log("");
+        console.log("Examples:");
+        console.log("  set-presence playing with Yukki");
+        console.log("  set-presence watching over senpai");
+        console.log("  set-presence status dnd");
+        console.log("  set-presence clear");
+        return;
+    }
+
+    const subcommand = args[0].toLowerCase();
+
+    // Handle clear
+    if (subcommand === "clear" || subcommand === "reset" || subcommand === "none") {
+        try {
+            await yuno.dC.user.setPresence({
+                activities: [],
+                status: "online"
+            });
+            console.log("Presence cleared.");
+        } catch (e) {
+            console.log(`Failed to clear presence: ${e.message}`);
+        }
+        return;
+    }
+
+    // Handle status change
+    if (subcommand === "status") {
+        const status = args[1]?.toLowerCase();
+
+        if (!status || !STATUS_OPTIONS.includes(status)) {
+            console.log(`Invalid status. Options: ${STATUS_OPTIONS.join(", ")}`);
+            return;
+        }
+
+        try {
+            await yuno.dC.user.setPresence({ status });
+            console.log(`Status set to: ${status}`);
+        } catch (e) {
+            console.log(`Failed to set status: ${e.message}`);
+        }
+        return;
+    }
+
+    // Handle activity type
+    const activityType = ACTIVITY_TYPES[subcommand];
+
+    if (activityType === undefined) {
+        console.log(`Unknown type: ${subcommand}`);
+        console.log(`Valid types: ${Object.keys(ACTIVITY_TYPES).join(", ")}`);
+        return;
+    }
+
+    let activityText = args.slice(1).join(" ");
+    let streamUrl = null;
+
+    if (activityType === ActivityType.Streaming) {
+        const urlMatch = activityText.match(/(https?:\/\/[^\s]+)/);
+        if (urlMatch) {
+            streamUrl = urlMatch[1];
+            activityText = activityText.replace(streamUrl, "").trim();
+        }
+
+        if (!streamUrl) {
+            console.log("Streaming requires a URL!");
+            return;
+        }
+    }
+
+    if (!activityText) {
+        console.log("Please provide activity text!");
+        return;
+    }
+
+    try {
+        const activity = {
+            name: activityText,
+            type: activityType
+        };
+
+        if (streamUrl) {
+            activity.url = streamUrl;
+        }
+
+        await yuno.dC.user.setPresence({
+            activities: [activity]
+        });
+
+        console.log(`Now ${subcommand} ${activityText}${streamUrl ? ` (${streamUrl})` : ""}`);
+    } catch (e) {
+        console.log(`Failed to set presence: ${e.message}`);
+    }
 }
 
 module.exports.about = {
     "command": "set-presence",
-    "onlyMasterUsers": true
+    "description": "Set the bot's activity status and online presence.",
+    "usage": "set-presence <type> <text> | set-presence status <status> | set-presence clear",
+    "examples": [
+        "set-presence playing with Yukki",
+        "set-presence watching over senpai",
+        "set-presence listening to Future Diary OST",
+        "set-presence streaming My Stream https://twitch.tv/example",
+        "set-presence status dnd",
+        "set-presence clear"
+    ],
+    "discord": true,
+    "terminal": true,
+    "list": true,
+    "listTerminal": true,
+    "onlyMasterUsers": true,
+    "aliases": ["presence", "activity", "setstatus"]
 }


### PR DESCRIPTION
## Summary
- Implemented complete `set-presence` command replacing the empty stub
- Added support for all Discord.js activity types (playing, watching, listening, streaming, competing)
- Added status options (online, idle, dnd, invisible)
- Added clear/reset functionality
- Works in both Discord and terminal
- Updated README with command documentation

## Features
**Activity Types:**
- `set-presence playing <text>` - Playing status
- `set-presence watching <text>` - Watching status
- `set-presence listening <text>` - Listening to status
- `set-presence streaming <text> <url>` - Streaming with URL
- `set-presence competing <text>` - Competing in status

**Status Options:**
- `set-presence status online` - Green dot
- `set-presence status idle` - Yellow dot
- `set-presence status dnd` - Red dot
- `set-presence status invisible` - Appear offline

**Other:**
- `set-presence clear` - Clear current activity
- Aliases: `presence`, `activity`, `setstatus`

## Test plan
- [ ] Test `set-presence playing <text>` in Discord
- [ ] Test `set-presence watching <text>` in Discord
- [ ] Test `set-presence listening <text>` in Discord
- [ ] Test `set-presence streaming <text> <url>` with Twitch URL
- [ ] Test `set-presence status dnd` changes bot status
- [ ] Test `set-presence clear` removes activity
- [ ] Test terminal execution of all commands
- [ ] Test help display with no arguments

🤖 Generated with [Claude Code](https://claude.com/claude-code)