### PR TITLE
Code optimizations and async/await fixes

### DIFF
--- a/src/Util.js
+++ b/src/Util.js
@@ -15,12 +15,12 @@ module.exports = {
      * @return {TextChannel} The new and empty channel.
      */
     "clean": async function(channel) {
-        let nsfw = channel.nsfw,
-            pos = channel.position,
-            oldId = channel.id;
+        const nsfw = channel.nsfw;
+        const pos = channel.position;
+        const oldId = channel.id;
 
         // Clone the channel
-        let n = await channel.clone({
+        const n = await channel.clone({
             "reason": "Cleaning by Yuno."
         });
 
@@ -60,19 +60,19 @@ module.exports = {
      * @return {String}
      */
     "formatDuration": function(seconds) {
-        let h = Math.floor(seconds / 3600),
-            min = Math.floor((seconds - (h * 3600)) / 60),
-            sec = seconds - (h * 3600) - (min * 60),
-            r = "";
+        const h = Math.floor(seconds / 3600);
+        const min = Math.floor((seconds - (h * 3600)) / 60);
+        const sec = seconds - (h * 3600) - (min * 60);
+        let r = "";
 
         if (h > 0)
-            r += ("00" + h).slice(-2) + "h "
+            r += String(h).padStart(2, '0') + "h ";
 
         if (min > 0)
-            r += ("00" + min).slice(-2) + "min "
+            r += String(min).padStart(2, '0') + "min ";
 
-        if (sec > 0)
-            r += ("00" + sec).slice(-2) + "s"
+        if (sec > 0 || r === "")
+            r += String(sec).padStart(2, '0') + "s";
 
         return r;
     },
@@ -83,9 +83,12 @@ module.exports = {
      * @return {boolean}
      */
     "checkIfUrl": function(url) {
-        return (
-            /(http|https):\/\/(\w+:{0,1}\w*)?(\S+)(:[0-9]+)?(\/|\/([\w#!:.?+=&%!\-\/]))?/
-        ).test(url)
+        try {
+            const parsed = new URL(url);
+            return parsed.protocol === 'http:' || parsed.protocol === 'https:';
+        } catch {
+            return false;
+        }
     },
 
     /**

--- a/src/commands/drop-errors-on.js
+++ b/src/commands/drop-errors-on.js
@@ -20,12 +20,15 @@ module.exports.run = async function(yuno, author, args, msg) {
     if (!msg.mentions.channels.size)
         return msg.channel.send("Please mention a channel.");
 
+    const channel = msg.mentions.channels.first();
+
     yuno.config.set("errors.dropon", {
         "guild": msg.guild.id,
-        "channel": msg.mentions.channels.first().name
+        "channel": channel.name
     });
 
-    await yuno._refreshMod("bot-errors")
+    await yuno._refreshMod("bot-errors");
+    await msg.channel.send(`:white_check_mark: Errors will now be sent to ${channel}.`);
 }
 
 module.exports.about = {

--- a/src/commands/praise.js
+++ b/src/commands/praise.js
@@ -23,7 +23,7 @@ module.exports.run = async function(yuno, author, args, msg) {
         return msg.channel.send('Who do you want me to praise?');
     }
 
-    msg.channel.send(msg.mentions.users.first().toString() + praise[Math.floor(Math.random() * praise.length)])
+    await msg.channel.send(msg.mentions.users.first().toString() + praise[Math.floor(Math.random() * praise.length)])
 };
 
 module.exports.about = {

--- a/src/commands/quote.js
+++ b/src/commands/quote.js
@@ -19,7 +19,7 @@
 const quote = require('../data/quotes.json')
 
 module.exports.run = async function(yuno, author, args, msg) {
-    msg.channel.send(quote[Math.floor(Math.random() * quote.length)])
+    await msg.channel.send(quote[Math.floor(Math.random() * quote.length)])
 };
 
 module.exports.about = {

--- a/src/commands/scold.js
+++ b/src/commands/scold.js
@@ -23,7 +23,7 @@ module.exports.run = async function(yuno, author, args, msg) {
         return msg.channel.send('Who do you want me to scold?');
     }
 
-    msg.channel.send(msg.mentions.users.first().toString() + scold[Math.floor(Math.random() * scold.length)])
+    await msg.channel.send(msg.mentions.users.first().toString() + scold[Math.floor(Math.random() * scold.length)])
 };
 
 module.exports.about = {

--- a/src/commands/set-prefix.js
+++ b/src/commands/set-prefix.js
@@ -24,8 +24,9 @@ module.exports.run = async function(yuno, author, args, msg) {
     else
         prefix = args[0];
 
-    let oldPrefixes = await yuno.dbCommands.getPrefixes(yuno.database);
+    const oldPrefixes = await yuno.dbCommands.getPrefixes(yuno.database);
 
+    let oldPrefix;
     if (Object.keys(oldPrefixes).includes(msg.guild.id))
         oldPrefix = oldPrefixes[msg.guild.id];
     else
@@ -37,7 +38,7 @@ module.exports.run = async function(yuno, author, args, msg) {
     await yuno.dbCommands.setPrefix(yuno.database, msg.guild.id, prefix);
 
     yuno._refreshMod("command-executor");
-    return msg.channel.send(":white_check_mark: Prefix changed to : `"+ prefix +" `\n:arrow_right: Hot reloading the command-executor module... Bot may be unresponsive for a few secs.");
+    return await msg.channel.send(":white_check_mark: Prefix changed to : `"+ prefix +" `\n:arrow_right: Hot reloading the command-executor module... Bot may be unresponsive for a few secs.");
 }
 
 module.exports.about = {


### PR DESCRIPTION
## Summary
- Modernize `Util.js` with `String.padStart()` and native `URL` constructor
- Add missing `await` keywords to async `msg.channel.send()` calls
- Fix undeclared variable bug in `set-prefix.js`
- Add confirmation message to `drop-errors-on.js`

## Changes

### Util.js
- Replace `("00" + h).slice(-2)` with `String(h).padStart(2, '0')` for cleaner code
- Fix edge case: `formatDuration(0)` now returns `"00s"` instead of empty string
- Replace regex URL validation with native `URL` constructor (more robust)
- Change `let` to `const` for non-reassigned variables

### Commands
| File | Fix |
|------|-----|
| praise.js | Add `await` to `msg.channel.send()` |
| quote.js | Add `await` to `msg.channel.send()` |
| scold.js | Add `await` to `msg.channel.send()` |
| set-prefix.js | Fix undeclared `oldPrefix` (implicit global), add `await` |
| drop-errors-on.js | Add confirmation message, proper `await` |

## Test plan
- [ ] Run `.praise @user` and verify response
- [ ] Run `.quote` and verify response
- [ ] Run `.scold @user` and verify response
- [ ] Run `.set-prefix !` and verify confirmation
- [ ] Run `.drop-errors-on #channel` and verify new confirmation message

🤖 Generated with [Claude Code](https://claude.com/claude-code)