### PR TITLE
Add async/await to all modules and fix Discord.js v14 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yuno-gasai-2",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "description": "The remade of Yuno Gasai, flawless & bugless",
   "main": "index.js",
   "scripts": {

--- a/src/commands/del-banimage.js
+++ b/src/commands/del-banimage.js
@@ -20,17 +20,18 @@ module.exports.run = async function(yuno, author, args, msg) {
     let user = msg.member;
 
     if (msg.mentions.users.size) {
-        let target = msg.mentions.users.first();
-        if (yuno.commandMan._isUserMaster(msg.author.id) || msg.member.roles.highest.comparePositionTo(msg.guild.members.get(target.id).roles.highest) > 0)
+        const target = msg.mentions.users.first();
+        const targetMember = msg.guild.members.cache.get(target.id);
+        if (targetMember && (yuno.commandMan._isUserMaster(msg.author.id) || msg.member.roles.highest.comparePositionTo(targetMember.roles.highest) > 0))
             user = target;
     }
 
-    let r = await yuno.dbCommands.delBanImage(yuno.database, msg.guild.id, user.id)
+    await yuno.dbCommands.delBanImage(yuno.database, msg.guild.id, user.id);
 
     if (user.id === msg.author.id)
-        return msg.channel.send(":white_check_mark: Your ban image has been deleted!");
+        return await msg.channel.send(":white_check_mark: Your ban image has been deleted!");
     else
-        return msg.channel.send(":white_check_mark: **" + user.user.username + "**'s ban image has been deleted!");
+        return await msg.channel.send(":white_check_mark: **" + (user.user?.username || user.username) + "**'s ban image has been deleted!");
 }
 
 module.exports.about = {

--- a/src/commands/demo.js
+++ b/src/commands/demo.js
@@ -19,9 +19,8 @@
 module.exports.run = async function(yuno, author, args, msg) {
     if (author === 0)
         yuno.prompt.info("Modified!");
-    else
-        if (msg)
-            msg.reply("Hey xd");
+    else if (msg)
+        await msg.reply("Hey xd");
 }
 
 module.exports.about = {

--- a/src/commands/set-banimage.js
+++ b/src/commands/set-banimage.js
@@ -18,25 +18,26 @@
 
 module.exports.run = async function(yuno, author, args, msg) {
     if (args.length === 0)
-        return msg.channel.send(":negative_squared_cross_mark: Not enough arguments.");
+        return await msg.channel.send(":negative_squared_cross_mark: Not enough arguments.");
 
     if (!yuno.UTIL.checkIfUrl(args[0]))
-        return msg.channel.send(":negative_squared_cross_mark: The first argument provided isn't a URL as required.");
-    
+        return await msg.channel.send(":negative_squared_cross_mark: The first argument provided isn't a URL as required.");
+
     let user = msg.member;
 
     if (msg.mentions.users.size) {
-        let target = msg.mentions.users.first();
-        if (yuno.commandMan._isUserMaster(msg.author.id) || msg.member.roles.highest.comparePositionTo(msg.guild.members.get(target.id).roles.highest) > 0)
+        const target = msg.mentions.users.first();
+        const targetMember = msg.guild.members.cache.get(target.id);
+        if (targetMember && (yuno.commandMan._isUserMaster(msg.author.id) || msg.member.roles.highest.comparePositionTo(targetMember.roles.highest) > 0))
             user = target;
     }
 
-    let r = await yuno.dbCommands.setBanImage(yuno.database, msg.guild.id, user.id, args[0])
+    const r = await yuno.dbCommands.setBanImage(yuno.database, msg.guild.id, user.id, args[0]);
 
     if (r[0] === "creating")
-        return msg.channel.send(":white_check_mark: Ban image set!");
+        return await msg.channel.send(":white_check_mark: Ban image set!");
     else
-        return msg.channel.send(":white_check_mark: Ban image updated!");
+        return await msg.channel.send(":white_check_mark: Ban image updated!");
 }
 
 module.exports.about = {

--- a/src/modules/activity-logger.js
+++ b/src/modules/activity-logger.js
@@ -500,9 +500,9 @@ let discordConnected = async function(Yuno) {
     DISCORD_EVENTED = true;
 };
 
-module.exports.init = function(Yuno, hotReloaded) {
+module.exports.init = async function(Yuno, hotReloaded) {
     if (hotReloaded)
-        discordConnected(Yuno);
+        await discordConnected(Yuno);
     else
         Yuno.on("discord-connected", discordConnected);
 };

--- a/src/modules/auto-cleaner.js
+++ b/src/modules/auto-cleaner.js
@@ -141,11 +141,11 @@ const setupCleaners = async (Yuno) => {
 
 module.exports.configLoaded = function() {};
 
-module.exports.init = function(Yuno, hotreloaded) {
+module.exports.init = async function(Yuno, hotreloaded) {
     intervalManager = Yuno.intervalMan;
 
     if (hotreloaded) {
-        setupCleaners(Yuno);
+        await setupCleaners(Yuno);
     } else {
         // Use arrow function instead of .bind()
         Yuno.on("discord-connected", () => setupCleaners(Yuno));

--- a/src/modules/auto-role-restore.js
+++ b/src/modules/auto-role-restore.js
@@ -73,11 +73,11 @@ let discordConnected = async function(Yuno) {
     DISCORD_EVENTED = true;
 };
 
-module.exports.init = function(Yuno, hotReloaded) {
+module.exports.init = async function(Yuno, hotReloaded) {
     if (hotReloaded)
-        discordConnected(Yuno);
+        await discordConnected(Yuno);
     else
-        Yuno.on("discord-connected", discordConnected)
+        Yuno.on("discord-connected", discordConnected);
 }
 
 module.exports.configLoaded = function() {}

--- a/src/modules/auto-update-checker.js
+++ b/src/modules/auto-update-checker.js
@@ -190,12 +190,12 @@ async function resolveErrorChannel() {
     }
 }
 
-module.exports.init = function(Yuno, hotReloaded) {
+module.exports.init = async function(Yuno, hotReloaded) {
     yuno = Yuno;
 
     if (hotReloaded) {
         // Re-resolve channel and restart schedule on hot-reload
-        resolveErrorChannel();
+        await resolveErrorChannel();
         startSchedule();
     } else {
         Yuno.on("discord-connected", async () => {

--- a/src/modules/bot-errors.js
+++ b/src/modules/bot-errors.js
@@ -86,16 +86,16 @@ const discordConnected = async function(Yuno) {
     Yuno.prompt.info(`Errors logged on ${guild.name} in #${channel.name}`);
 };
 
-module.exports.init = function(Yuno, hotReloaded) {
+module.exports.init = async function(Yuno, hotReloaded) {
     if (hotReloaded) {
-        discordConnected(Yuno);
+        await discordConnected(Yuno);
     } else {
         Yuno.on("discord-connected", discordConnected);
     }
 
     if (!ONE_TIME_EVENT) {
         // Use arrow function instead of .bind()
-        Yuno.on("error", (e) => {
+        Yuno.on("error", async (e) => {
             if (guild && channel) {
                 const possibleMoreInfo = ["From"];
                 const moreInfo = possibleMoreInfo
@@ -107,7 +107,7 @@ module.exports.init = function(Yuno, hotReloaded) {
                     ? `${e.message}\nMore information: ${moreInfo}`
                     : e.message;
 
-                channel.send(`${getMentions()}An exception happened :'(.\`\`\`${errorString}\`\`\``);
+                await channel.send(`${getMentions()}An exception happened :'(.\`\`\`${errorString}\`\`\``);
             }
         });
     }

--- a/src/modules/command-executor.js
+++ b/src/modules/command-executor.js
@@ -107,11 +107,11 @@ let discordConnected = async function(yuno) {
     ONE_TIME_EVENT = true;
 }
 
-module.exports.init = function(Yuno, hotReloaded) {
+module.exports.init = async function(Yuno, hotReloaded) {
     if (hotReloaded)
-        discordConnected(Yuno)
+        await discordConnected(Yuno);
     else
-        Yuno.on("discord-connected", discordConnected)
+        Yuno.on("discord-connected", discordConnected);
 }
 
 module.exports.configLoaded = function(Yuno, config) {

--- a/src/modules/dm-handler.js
+++ b/src/modules/dm-handler.js
@@ -225,9 +225,9 @@ let discordConnected = async function(Yuno) {
     }, 24 * 60 * 60 * 1000);
 };
 
-module.exports.init = function(Yuno, hotReloaded) {
+module.exports.init = async function(Yuno, hotReloaded) {
     if (hotReloaded)
-        discordConnected(Yuno);
+        await discordConnected(Yuno);
     else
         Yuno.on("discord-connected", discordConnected);
 };

--- a/src/modules/invite-deletor.js
+++ b/src/modules/invite-deletor.js
@@ -43,16 +43,11 @@ let discordConnected = async function(Yuno) {
     DISCORD_EVENTED = true;
 };
 
-module.exports.init = function(Yuno, hotReloaded) {
+module.exports.init = async function(Yuno, hotReloaded) {
     if (hotReloaded)
-        discordConnected(Yuno);
+        await discordConnected(Yuno);
     else
-        Yuno.on("discord-connected", discordConnected)
+        Yuno.on("discord-connected", discordConnected);
 }
 
-module.exports.configLoaded = async function(Yuno, config) {
-    let presenceData_ = await config.get("discord.presence");
-
-    if (typeof presenceData_ === "object")
-        presenceData = presenceData_; 
-}
+module.exports.configLoaded = function() {}

--- a/src/modules/join-dm-msg.js
+++ b/src/modules/join-dm-msg.js
@@ -28,10 +28,10 @@ let DISCORD_EVENTED = false,
 module.exports.modulename = "join-dm-msg";
 
 let discordConnected = async function(Yuno) {
-    DBCmds = Yuno.dbCommands,
-    discord = Yuno.dC
-    jdmmsg = await DBCmds.getJoinDMMessages(Yuno.database),
-    jdmmsgt = await DBCmds.getJoinDMMessagesTitles(Yuno.database)
+    DBCmds = Yuno.dbCommands;
+    discord = Yuno.dC;
+    jdmmsg = await DBCmds.getJoinDMMessages(Yuno.database);
+    jdmmsgt = await DBCmds.getJoinDMMessagesTitles(Yuno.database);
 
     eventDiscord();
 };
@@ -69,11 +69,11 @@ let eventDiscord = function() {
     })
 }
 
-module.exports.init = function(Yuno, hotReloaded) {
+module.exports.init = async function(Yuno, hotReloaded) {
     if (hotReloaded)
-        discordConnected(Yuno);
+        await discordConnected(Yuno);
     else
-        Yuno.on("discord-connected", discordConnected)
+        Yuno.on("discord-connected", discordConnected);
 }
 
 module.exports.configLoaded = function() {}

--- a/src/modules/presence.js
+++ b/src/modules/presence.js
@@ -106,11 +106,11 @@ function convertToV14Presence(oldPresence) {
     return newPresence;
 }
 
-module.exports.init = function(Yuno, hotReloaded) {
+module.exports.init = async function(Yuno, hotReloaded) {
     if (hotReloaded)
-        discordConnected(Yuno);
+        await discordConnected(Yuno);
     else
-        Yuno.on("discord-connected", discordConnected)
+        Yuno.on("discord-connected", discordConnected);
 }
 
 module.exports.configLoaded = async function(Yuno, config) {

--- a/src/modules/slash-commands.js
+++ b/src/modules/slash-commands.js
@@ -332,9 +332,9 @@ async function discordConnected(yuno) {
     ONE_TIME_EVENT = true;
 }
 
-module.exports.init = function(yuno, hotReloaded) {
+module.exports.init = async function(yuno, hotReloaded) {
     if (hotReloaded) {
-        discordConnected(yuno);
+        await discordConnected(yuno);
     } else {
         yuno.on("discord-connected", discordConnected);
     }

--- a/src/modules/vc-xp.js
+++ b/src/modules/vc-xp.js
@@ -277,9 +277,9 @@ let discordConnected = async function(Yuno) {
     await recoverSessions();
 };
 
-module.exports.init = function(Yuno, hotReloaded) {
+module.exports.init = async function(Yuno, hotReloaded) {
     if (hotReloaded)
-        discordConnected(Yuno);
+        await discordConnected(Yuno);
     else
         Yuno.on("discord-connected", discordConnected);
 };


### PR DESCRIPTION
## Summary
- Add proper `async`/`await` to all module `init()` functions
- Fix Discord.js v14 compatibility issues in commands
- Bump version to 2.6.3

## Modules Updated
All modules now properly use `async` for `init()` and `await` when calling `discordConnected()` on hot-reload:

| Module | Changes |
|--------|---------|
| activity-logger.js | Added async/await |
| auto-cleaner.js | Added async/await |
| auto-role-restore.js | Added async/await |
| auto-update-checker.js | Added async/await |
| bot-errors.js | Added async/await + await on channel.send |
| command-executor.js | Added async/await |
| dm-handler.js | Added async/await |
| invite-deletor.js | Added async/await, removed broken configLoaded |
| join-dm-msg.js | Added async/await, fixed comma operators → semicolons |
| presence.js | Added async/await |
| slash-commands.js | Added async/await |
| vc-xp.js | Added async/await |

## Commands Fixed
| Command | Fix |
|---------|-----|
| del-banimage.js | `msg.guild.members.get()` → `.cache.get()`, added await |
| set-banimage.js | `msg.guild.members.get()` → `.cache.get()`, added await |
| demo.js | Added await to `msg.reply()` |

## Test plan
- [ ] Hot-reload modules and verify no errors
- [ ] Test `.set-banimage` with mentioned user
- [ ] Test `.del-banimage` with mentioned user
- [ ] Verify error logging works in bot-errors channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)