### PR TITLE
Upgrade to Node.js 24 and use new JavaScript features

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 <img src="https://i.imgur.com/jF8Szfr.png" alt="Yuno Gasai" width="300"/>
 
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL%20v3-pink.svg)](https://www.gnu.org/licenses/agpl-3.0)
-[![Node.js](https://img.shields.io/badge/Node.js-22.x%20LTS-ff69b4.svg)](https://nodejs.org/)
+[![Node.js](https://img.shields.io/badge/Node.js-24.x-ff69b4.svg)](https://nodejs.org/)
 [![Discord.js](https://img.shields.io/badge/Discord.js-v14-ff1493.svg)](https://discord.js.org/)
 
 *A devoted Discord bot for moderation, leveling, and anime~ ♥*
@@ -172,30 +172,30 @@ Yuno is a **yandere-themed Discord bot** combining powerful moderation tools wit
 
 > *"Let me prepare everything for you~"* 💗
 
-- **Node.js** 22.x LTS or higher
+- **Node.js** 24.x or higher
 - **node-gyp** & **build-essential** (make)
 - **SQLite3**
 - **Git**
 - **tmux** *(optional, for interactive shell)*
 
-### 🔧 Installing Node.js 22
+### 🔧 Installing Node.js 24
 
 <details>
 <summary><b>🐧 Linux (Ubuntu/Debian)</b></summary>
 
 ```bash
 # Using NodeSource repository (recommended)
-curl -fsSL https://deb.nodesource.com/setup_22.x | sudo -E bash -
+curl -fsSL https://deb.nodesource.com/setup_24.x | sudo -E bash -
 sudo apt-get install -y nodejs
 
 # Or using nvm (Node Version Manager)
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
 source ~/.bashrc
-nvm install 22
-nvm use 22
+nvm install 24
+nvm use 24
 
 # Verify installation
-node --version  # Should show v22.x.x
+node --version  # Should show v24.x.x
 ```
 
 **Also install build tools:**
@@ -210,31 +210,31 @@ sudo apt-get install -y build-essential python3
 
 **Option 1: Direct Download (Recommended)**
 1. Go to [Node.js Downloads](https://nodejs.org/en/download/)
-2. Download the **Windows Installer (.msi)** for version 22.x LTS
+2. Download the **Windows Installer (.msi)** for version 24.x
 3. Run the installer and follow the prompts
 4. Ensure "Automatically install necessary tools" is checked
 
 **Option 2: Using winget**
 ```powershell
-winget install OpenJS.NodeJS.LTS
+winget install OpenJS.NodeJS
 ```
 
 **Option 3: Using Chocolatey**
 ```powershell
-choco install nodejs-lts
+choco install nodejs
 ```
 
 **Option 4: Using nvm-windows**
 1. Download [nvm-windows](https://github.com/coreybutler/nvm-windows/releases)
 2. Install and run:
 ```powershell
-nvm install 22
-nvm use 22
+nvm install 24
+nvm use 24
 ```
 
 **Verify installation:**
 ```powershell
-node --version  # Should show v22.x.x
+node --version  # Should show v24.x.x
 ```
 
 </details>
@@ -244,16 +244,16 @@ node --version  # Should show v22.x.x
 
 ```bash
 # Using Homebrew (recommended)
-brew install node@22
+brew install node@24
 
 # Or using nvm
 curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
 source ~/.zshrc
-nvm install 22
-nvm use 22
+nvm install 24
+nvm use 24
 
 # Verify installation
-node --version  # Should show v22.x.x
+node --version  # Should show v24.x.x
 ```
 
 </details>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yuno-gasai-2",
-  "version": "2.6.3",
+  "version": "2.7.0",
   "description": "The remade of Yuno Gasai, flawless & bugless",
   "main": "index.js",
   "scripts": {
@@ -11,7 +11,7 @@
     "generate-doc-notheme": "jsdoc .\\src -r -p -d docs"
   },
   "engines": {
-    "node": ">=18.0.0"
+    "node": ">=24.0.0"
   },
   "devDependencies": {
     "docdash": "^2.0.2",

--- a/src/Yuno.js
+++ b/src/Yuno.js
@@ -114,7 +114,7 @@ class Yuno extends EventEmitter {
         this.interactivity = true;
 
         this.version = PACKAGE.version;
-        this.intVersion = parseInt(PACKAGE.version.replace(new RegExp("[.]", "gi"), ""), 10);
+        this.intVersion = parseInt(PACKAGE.version.replaceAll(".", ""), 10);
 
         this.prompt.info("Yuno " + this.version + " initialised.")
 

--- a/src/commands/config.js
+++ b/src/commands/config.js
@@ -39,7 +39,7 @@ const ACTION_HANDLERS = {
     },
     get: (config, key, value, yuno) => {
         const result = tryStringifyJSON(config.get(key));
-        return String(result).replace(new RegExp(yuno.dC.token, "gi"), "[token]");
+        return String(result).replace(new RegExp(RegExp.escape(yuno.dC.token), "gi"), "[token]");
     }
 };
 

--- a/src/commands/eval.js
+++ b/src/commands/eval.js
@@ -38,7 +38,7 @@ module.exports.run = async function(yuno, author, args, msg) {
     }
 
     result = typeof result === "string"
-        ? result.replace(new RegExp(yuno.dC.token, "gi"), "[token]")
+        ? result.replace(new RegExp(RegExp.escape(yuno.dC.token), "gi"), "[token]")
         : util.inspect(result, { depth: 0 });
 
     if (isSilent && author !== 0) {

--- a/src/commands/set-joinmessage.js
+++ b/src/commands/set-joinmessage.js
@@ -26,10 +26,10 @@ module.exports.run = async function(yuno, author, args, msg) {
         guildid = msg.guild.id;
 
     if (args.length === 1) {
-        desc = args[0].replace(new RegExp("_", "gi"), " ");
-        msg.channel.send(":warning: No title given. The given title will be the description's embed.");
+        desc = args[0].replaceAll("_", " ");
+        await msg.channel.send(":warning: No title given. The given title will be the description's embed.");
     } else {
-        title = args[0].replace(new RegExp("_", "gi"), " ");
+        title = args[0].replaceAll("_", " ");
         desc = args.slice(1).join(" ");
     }
 
@@ -45,7 +45,7 @@ module.exports.run = async function(yuno, author, args, msg) {
 
     yuno._refreshMod("join-dm-msg");
 
-    msg.channel.send({embeds: [new EmbedBuilder()
+    await msg.channel.send({embeds: [new EmbedBuilder()
         .setTitle(":white_check_mark:")
         .addFields([
             {name: "DM Message's title", value: typeof title === "string" ? title : "none", inline: true},

--- a/src/lib/commandManager.js
+++ b/src/lib/commandManager.js
@@ -341,7 +341,7 @@ class CommandManager extends EventEmitter {
                     _error = e;
                 }
 
-                if (_error instanceof Error)
+                if (Error.isError(_error))
                     throw _error; // let yuno handle the error.
             } else {
                 // command execution failed due to insufficient permissions

--- a/src/lib/prompt.js
+++ b/src/lib/prompt.js
@@ -166,7 +166,7 @@ class Prompt {
      * @param {String} [textColor]
      */
     error(text, error, textColor) {
-        if (error instanceof Error) {
+        if (Error.isError(error)) {
             text += " : ";
 
             if (error.code)

--- a/src/message-processors/mention-responses.js
+++ b/src/message-processors/mention-responses.js
@@ -7,15 +7,14 @@ let mentionResponses = [];
 module.exports.message = async function(content, msg) {
     for (const mentionResponse of mentionResponses) {
         if (msg.guild.id === mentionResponse.guildId && msg.content.toLowerCase().replace(msg.client.user.toString(), '').trim().includes(mentionResponse.trigger.trim()) && msg.mentions.members.has(msg.client.user.id)) {
-            let embed = new EmbedBuilder()
-                    .setDescription(mentionResponse.response.replace(new RegExp("[$]{author}", "gi"), msg.author.username))
-                    .setColor("#ff51ff"),
-                image;
+            const embed = new EmbedBuilder()
+                .setDescription(mentionResponse.response.replaceAll("${author}", msg.author.username))
+                .setColor("#ff51ff");
 
             if (mentionResponse.image !== "null")
                 embed.setImage(mentionResponse.image);
 
-            msg.channel.send({embeds: [embed]})
+            await msg.channel.send({embeds: [embed]});
             break;
         }
     }


### PR DESCRIPTION
## Summary
Upgrade Yuno to require Node.js 24 and take advantage of new JavaScript features introduced in V8 13.6.

## Node.js 24 Features Used

### Error.isError()
Reliably detect Error instances across different realms (more robust than `instanceof`):
```javascript
// Before
if (error instanceof Error)

// After  
if (Error.isError(error))
```

### RegExp.escape()
Safely escape special characters when building dynamic regex patterns:
```javascript
// Before - could break if token contains special chars
new RegExp(yuno.dC.token, "gi")

// After - safe for any input
new RegExp(RegExp.escape(yuno.dC.token), "gi")
```

### String.replaceAll()
Cleaner string replacements without regex:
```javascript
// Before
str.replace(new RegExp("[.]", "gi"), "")

// After
str.replaceAll(".", "")
```

## Files Changed

| File | Change |
|------|--------|
| `package.json` | Require Node.js >= 24.0.0, bump to v2.7.0 |
| `README.md` | Update installation guides for Node.js 24 |
| `src/lib/prompt.js` | Use `Error.isError()` |
| `src/lib/commandManager.js` | Use `Error.isError()` |
| `src/commands/config.js` | Use `RegExp.escape()` for token redaction |
| `src/commands/eval.js` | Use `RegExp.escape()` for token redaction |
| `src/commands/set-joinmessage.js` | Use `replaceAll()` |
| `src/Yuno.js` | Use `replaceAll()` for version parsing |
| `src/message-processors/mention-responses.js` | Use `replaceAll()`, add missing `await` |

## Test plan
- [ ] Verify bot starts on Node.js 24
- [ ] Test `.config get` command (token redaction)
- [ ] Test `.eval` command (token redaction)
- [ ] Test `.set-joinmessage` command
- [ ] Verify error handling in commands

## References
- [Node.js 24 Release Notes](https://nodejs.org/en/blog/release/v24.0.0)
- [What's New in Node.js 24](https://blog.appsignal.com/2025/05/09/whats-new-in-nodejs-24.html)

🤖 Generated with [Claude Code](https://claude.com/claude-code)