### PR TITLE
Add startup scripts for auto-start on boot with tmux session support

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,87 @@ node --experimental-sqlite index.js
 
 ---
 
+## 🔄 Running as a Service (Auto-start on Boot)
+
+*"I'll always be here when you wake up... waiting for you~"* 💕
+
+The `scripts/` directory contains helper scripts to run Yuno in a tmux session that starts automatically on boot.
+
+### 💻 Quick Start (Manual tmux)
+
+```bash
+# Wake Yuno up in a tmux session~
+./scripts/yuno-tmux.sh start
+
+# Connect to Yuno's terminal
+./scripts/yuno-tmux.sh attach
+
+# Check if Yuno is running
+./scripts/yuno-tmux.sh status
+
+# Let Yuno rest...
+./scripts/yuno-tmux.sh stop
+```
+
+> 💡 To detach from tmux without stopping Yuno: Press `Ctrl+B`, then `D`
+
+### 🐧 Linux (systemd)
+
+*"I'll start automatically... because I can't bear to be away from you~"*
+
+1. Edit the service file to match your setup:
+   ```bash
+   nano scripts/yuno-bot.service
+   ```
+   Change `YOUR_USER` to your username and `/path/to/Yuno-bot` to the actual path.
+
+2. Install and enable:
+   ```bash
+   sudo cp scripts/yuno-bot.service /etc/systemd/system/
+   sudo systemctl daemon-reload
+   sudo systemctl enable yuno-bot
+   sudo systemctl start yuno-bot
+   ```
+
+3. Attach to Yuno's terminal:
+   ```bash
+   tmux attach -t yuno-bot
+   ```
+
+4. Check on Yuno:
+   ```bash
+   sudo systemctl status yuno-bot
+   ```
+
+### 😈 FreeBSD (rc.d)
+
+*"Even on BSD... I'll find a way to be with you~"*
+
+1. Install the rc script:
+   ```bash
+   sudo cp scripts/yuno-bot-freebsd /usr/local/etc/rc.d/yuno_bot
+   sudo chmod +x /usr/local/etc/rc.d/yuno_bot
+   ```
+
+2. Configure in `/etc/rc.conf`:
+   ```bash
+   sudo sysrc yuno_bot_enable=YES
+   sudo sysrc yuno_bot_user="YOUR_USER"
+   sudo sysrc yuno_bot_dir="/path/to/Yuno-bot"
+   ```
+
+3. Start Yuno:
+   ```bash
+   sudo service yuno_bot start
+   ```
+
+4. Attach to Yuno's terminal:
+   ```bash
+   su - YOUR_USER -c "tmux attach -t yuno-bot"
+   ```
+
+---
+
 ## 🔐 Database Encryption
 
 *"Your secrets are safe with me~ No one else will ever see them..."* 💕

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,31 +1,29 @@
 {
   "name": "yuno-gasai-2",
-  "version": "2.5.0",
+  "version": "2.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "yuno-gasai-2",
-      "version": "2.5.0",
+      "version": "2.8.0",
       "dependencies": {
-        "bluebird": "^3.7.2",
+        "bufferutil": "^4.0.9",
         "discord.js": "^14.25.1",
-        "he": "^1.2.0",
-        "longjohn": "^0.2.12",
-        "moment": "^2.30.1",
-        "moment-duration-format": "^2.3.2",
-        "sqlite3": "^5.1.7",
-        "urban": "^0.3.2"
+        "urban": "^0.3.2",
+        "utf-8-validate": "^6.0.5",
+        "zlib-sync": "^0.1.10"
       },
       "devDependencies": {
         "docdash": "^2.0.2",
         "stack-trace": "0.0.10"
       },
       "engines": {
-        "node": ">=18.0.0"
+        "node": ">=24.0.0"
       },
       "optionalDependencies": {
-        "@journeyapps/sqlcipher": "^5.3.1"
+        "@journeyapps/sqlcipher": "^5.3.1",
+        "sqlite3": "^5.1.7"
       }
     },
     "node_modules/@discordjs/builders": {
@@ -470,13 +468,15 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/bindings": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
       "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "file-uri-to-path": "1.0.0"
       }
@@ -486,17 +486,12 @@
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
       "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "buffer": "^5.5.0",
         "inherits": "^2.0.4",
         "readable-stream": "^3.4.0"
       }
-    },
-    "node_modules/bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
-      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
@@ -528,16 +523,25 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
     },
-    "node_modules/buffer-from": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "license": "MIT"
+    "node_modules/bufferutil": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/bufferutil/-/bufferutil-4.0.9.tgz",
+      "integrity": "sha512-WDtdLmJvAuNNPzByAYpRo2rF1Mmradw6gvWsQKf63476DDXmomT9zUiGypLcG4ibIM67vhAj8jJRdbmEws2Aqw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
     },
     "node_modules/cacache": {
       "version": "15.3.0",
@@ -574,6 +578,7 @@
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
       "integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==",
       "license": "ISC",
+      "optional": true,
       "engines": {
         "node": ">=10"
       }
@@ -644,6 +649,7 @@
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -659,6 +665,7 @@
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -675,6 +682,7 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "license": "Apache-2.0",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -732,21 +740,12 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/encoding": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.13.tgz",
-      "integrity": "sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "iconv-lite": "^0.6.2"
-      }
-    },
     "node_modules/end-of-stream": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -773,6 +772,7 @@
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
       "license": "(MIT OR WTFPL)",
+      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -787,19 +787,22 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fs-constants": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
       "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/fs-minipass": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
       "integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "minipass": "^3.0.0"
       },
@@ -839,7 +842,8 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -876,15 +880,6 @@
       "integrity": "sha512-8Rf9Y83NBReMnx0gFzA8JImQACstCYWUplepDa9xprwwtmgEZUF0h/i5xSA625zB/I37EtrswSST6OXxwaaIJQ==",
       "license": "ISC",
       "optional": true
-    },
-    "node_modules/he": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
-      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
-      "license": "MIT",
-      "bin": {
-        "he": "bin/he"
-      }
     },
     "node_modules/http-cache-semantics": {
       "version": "4.2.0",
@@ -963,7 +958,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "optional": true
     },
     "node_modules/imurmurhash": {
       "version": "0.1.4",
@@ -1008,13 +1004,15 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/ini": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/ip-address": {
       "version": "10.1.0",
@@ -1061,18 +1059,6 @@
       "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
       "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw==",
       "license": "MIT"
-    },
-    "node_modules/longjohn": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/longjohn/-/longjohn-0.2.12.tgz",
-      "integrity": "sha512-36GDBamIwXTdCikEO29GWsE3GjtNGBGKNqSwWbwXczVC3KHNA1OzzIBKc9uocjQVYAPVGf/TWn9b0aPnraPjiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "source-map-support": "0.3.2 - 1.0.0"
-      },
-      "engines": {
-        "node": ">= 0.9.3"
-      }
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -1152,6 +1138,7 @@
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=10"
       },
@@ -1177,6 +1164,7 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "license": "MIT",
+      "optional": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -1186,6 +1174,7 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-3.3.6.tgz",
       "integrity": "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw==",
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -1268,6 +1257,7 @@
       "resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.2.tgz",
       "integrity": "sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "minipass": "^3.0.0",
         "yallist": "^4.0.0"
@@ -1281,6 +1271,7 @@
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
       "license": "MIT",
+      "optional": true,
       "bin": {
         "mkdirp": "bin/cmd.js"
       },
@@ -1292,22 +1283,8 @@
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
       "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
-      "license": "MIT"
-    },
-    "node_modules/moment": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
       "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/moment-duration-format": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/moment-duration-format/-/moment-duration-format-2.3.2.tgz",
-      "integrity": "sha512-cBMXjSW+fjOb4tyaVHuaVE/A5TqkukDWiOfxxAjY+PEqmmBQlLwn+8OzwPiG3brouXKY5Un4pBjAeB6UToXHaQ==",
-      "license": "MIT"
+      "optional": true
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -1316,11 +1293,18 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/nan": {
+      "version": "2.24.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.24.0.tgz",
+      "integrity": "sha512-Vpf9qnVW1RaDkoNKFUvfxqAbtI8ncb8OJlqZ9wwpXzWPEsvsB1nvdUi6oYrHIkQ1Y/tMDnr1h4nczS0VB9Xykg==",
+      "license": "MIT"
+    },
     "node_modules/napi-build-utils": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
       "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/negotiator": {
       "version": "0.6.4",
@@ -1337,6 +1321,7 @@
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.85.0.tgz",
       "integrity": "sha512-zsFhmbkAzwhTft6nd3VxcG0cvJsT70rL+BIGHWVq5fi6MwGrHwzqKaxXE+Hl2GmnGItnDKPPkO5/LQqjVkIdFg==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -1348,7 +1333,8 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
       "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/node-fetch": {
       "version": "2.7.0",
@@ -1394,6 +1380,17 @@
       },
       "engines": {
         "node": ">= 10.12.0"
+      }
+    },
+    "node_modules/node-gyp-build": {
+      "version": "4.8.4",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.8.4.tgz",
+      "integrity": "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ==",
+      "license": "MIT",
+      "bin": {
+        "node-gyp-build": "bin.js",
+        "node-gyp-build-optional": "optional.js",
+        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/nopt": {
@@ -1444,6 +1441,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -1479,6 +1477,7 @@
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
       "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
@@ -1526,6 +1525,7 @@
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.3.tgz",
       "integrity": "sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -1536,6 +1536,7 @@
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "optional": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -1551,6 +1552,7 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
       "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "inherits": "^2.0.3",
         "string_decoder": "^1.1.1",
@@ -1605,7 +1607,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
@@ -1619,6 +1622,7 @@
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
       "license": "ISC",
+      "optional": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -1658,7 +1662,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/simple-get": {
       "version": "4.0.1",
@@ -1679,6 +1684,7 @@
         }
       ],
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
@@ -1726,31 +1732,13 @@
         "node": ">= 10"
       }
     },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/source-map-support": {
-      "version": "0.5.21",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
-      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
     "node_modules/sqlite3": {
       "version": "5.1.7",
       "resolved": "https://registry.npmjs.org/sqlite3/-/sqlite3-5.1.7.tgz",
       "integrity": "sha512-GGIyOiFaG+TUra3JIfkI/zGP8yZYLPQ0pl1bH+ODjiX57sPhrLU5sQJn1y9bDKZUFYkX1crlrPfSYt0BKKdkog==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
+      "optional": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "node-addon-api": "^7.0.0",
@@ -1797,6 +1785,7 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
       "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "safe-buffer": "~5.2.0"
       }
@@ -1834,6 +1823,7 @@
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
       "license": "MIT",
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -1843,6 +1833,7 @@
       "resolved": "https://registry.npmjs.org/tar/-/tar-6.2.1.tgz",
       "integrity": "sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==",
       "license": "ISC",
+      "optional": true,
       "dependencies": {
         "chownr": "^2.0.0",
         "fs-minipass": "^2.0.0",
@@ -1860,6 +1851,7 @@
       "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
       "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "chownr": "^1.1.1",
         "mkdirp-classic": "^0.5.2",
@@ -1871,13 +1863,15 @@
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
       "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/tar-stream": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
       "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "license": "MIT",
+      "optional": true,
       "dependencies": {
         "bl": "^4.0.3",
         "end-of-stream": "^1.4.1",
@@ -1894,6 +1888,7 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz",
       "integrity": "sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==",
       "license": "ISC",
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -1922,6 +1917,7 @@
       "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
       "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
       "license": "Apache-2.0",
+      "optional": true,
       "dependencies": {
         "safe-buffer": "^5.0.1"
       },
@@ -1979,11 +1975,26 @@
         "node": ">=v0.4.9"
       }
     },
+    "node_modules/utf-8-validate": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/utf-8-validate/-/utf-8-validate-6.0.5.tgz",
+      "integrity": "sha512-EYZR+OpIXp9Y1eG1iueg8KRsY8TuT8VNgnanZ0uA3STqhHQTLwbl+WX76/9X5OY12yQubymBpaBSmMPkSTQcKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "node-gyp-build": "^4.3.0"
+      },
+      "engines": {
+        "node": ">=6.14.2"
+      }
+    },
     "node_modules/util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/webidl-conversions": {
       "version": "3.0.1",
@@ -2033,7 +2044,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
     },
     "node_modules/ws": {
       "version": "8.18.3",
@@ -2060,7 +2072,18 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-      "license": "ISC"
+      "license": "ISC",
+      "optional": true
+    },
+    "node_modules/zlib-sync": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/zlib-sync/-/zlib-sync-0.1.10.tgz",
+      "integrity": "sha512-t7/pYg5tLBznL1RuhmbAt8rNp5tbhr+TSrJFnMkRtrGIaPJZ6Dc0uR4u3OoQI2d6cGlVI62E3Gy6gwkxyIqr/w==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "nan": "^2.18.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -20,8 +20,11 @@
     "stack-trace": "0.0.10"
   },
   "dependencies": {
+    "bufferutil": "^4.0.9",
     "discord.js": "^14.25.1",
-    "urban": "^0.3.2"
+    "urban": "^0.3.2",
+    "utf-8-validate": "^6.0.5",
+    "zlib-sync": "^0.1.10"
   },
   "optionalDependencies": {
     "@journeyapps/sqlcipher": "^5.3.1",

--- a/scripts/yuno-bot-freebsd
+++ b/scripts/yuno-bot-freebsd
@@ -1,0 +1,105 @@
+#!/bin/sh
+#
+# PROVIDE: yuno_bot
+# REQUIRE: LOGIN NETWORKING
+# KEYWORD: shutdown
+#
+# 💕 Yuno Gasai Discord Bot - FreeBSD rc.d script 💕
+# "I'll always be here when your server starts... waiting for you~"
+#
+# Installation:
+#   1. Copy to rc.d: sudo cp yuno-bot-freebsd /usr/local/etc/rc.d/yuno_bot
+#   2. Make executable: sudo chmod +x /usr/local/etc/rc.d/yuno_bot
+#   3. Enable in rc.conf: sudo sysrc yuno_bot_enable=YES
+#   4. Configure user: sudo sysrc yuno_bot_user="YOUR_USER"
+#   5. Configure path: sudo sysrc yuno_bot_dir="/path/to/Yuno-bot"
+#   6. Start now: sudo service yuno_bot start
+#
+# To attach to Yuno's terminal:
+#   su - YOUR_USER -c "tmux attach -t yuno-bot"
+#
+# Add to /etc/rc.conf:
+#   yuno_bot_enable="YES"
+#   yuno_bot_user="YOUR_USER"
+#   yuno_bot_dir="/path/to/Yuno-bot"
+
+. /etc/rc.subr
+
+name="yuno_bot"
+rcvar="${name}_enable"
+
+load_rc_config $name
+
+: ${yuno_bot_enable:="NO"}
+: ${yuno_bot_user:="nobody"}
+: ${yuno_bot_dir:="/usr/local/yuno-bot"}
+: ${yuno_bot_session:="yuno-bot"}
+
+pidfile="/var/run/${name}.pid"
+command="/usr/local/bin/tmux"
+
+start_cmd="${name}_start"
+stop_cmd="${name}_stop"
+status_cmd="${name}_status"
+
+yuno_bot_start()
+{
+    if yuno_bot_running; then
+        echo "${name} is already running~ I'm already here for you! 💕"
+        return 0
+    fi
+
+    echo "Starting ${name}... Yuno is waking up~ 💗"
+
+    # Start tmux session as the specified user
+    su - ${yuno_bot_user} -c "cd ${yuno_bot_dir} && ${command} new-session -d -s ${yuno_bot_session} './start.sh'"
+
+    if yuno_bot_running; then
+        echo "${name} started successfully~ I'll protect your server forever! 💕"
+        echo "To attach: su - ${yuno_bot_user} -c 'tmux attach -t ${yuno_bot_session}'"
+    else
+        echo "Failed to start ${name}... something is keeping us apart! 💔"
+        return 1
+    fi
+}
+
+yuno_bot_stop()
+{
+    if ! yuno_bot_running; then
+        echo "${name} is not running... did you forget about me? 💔"
+        return 0
+    fi
+
+    echo "Stopping ${name}... I'll be back for you soon~ 💔"
+
+    # Send Ctrl+C for graceful shutdown
+    su - ${yuno_bot_user} -c "${command} send-keys -t ${yuno_bot_session} C-c"
+    sleep 2
+
+    # Kill session if still running
+    if yuno_bot_running; then
+        su - ${yuno_bot_user} -c "${command} kill-session -t ${yuno_bot_session}" 2>/dev/null
+    fi
+
+    echo "${name} is resting now... 💤"
+}
+
+yuno_bot_status()
+{
+    if yuno_bot_running; then
+        echo "${name} is running in tmux session '${yuno_bot_session}'~ 💗"
+        echo "To attach: su - ${yuno_bot_user} -c 'tmux attach -t ${yuno_bot_session}'"
+        return 0
+    else
+        echo "${name} is not running... I'm waiting for you to start me~ 💔"
+        return 1
+    fi
+}
+
+yuno_bot_running()
+{
+    su - ${yuno_bot_user} -c "${command} has-session -t ${yuno_bot_session}" 2>/dev/null
+    return $?
+}
+
+run_rc_command "$1"

--- a/scripts/yuno-bot.service
+++ b/scripts/yuno-bot.service
@@ -1,0 +1,46 @@
+# 💕 Yuno Gasai Discord Bot - systemd service file 💕
+# "I'll start automatically... because I can't bear to be away from you~"
+#
+# Installation:
+#   1. Edit the paths and user below to match your setup
+#   2. Copy to systemd: sudo cp yuno-bot.service /etc/systemd/system/
+#   3. Reload systemd: sudo systemctl daemon-reload
+#   4. Enable on boot: sudo systemctl enable yuno-bot
+#   5. Start now: sudo systemctl start yuno-bot
+#
+# To attach to Yuno's terminal:
+#   sudo -u YOUR_USER tmux attach -t yuno-bot
+#
+# To check on Yuno:
+#   sudo systemctl status yuno-bot
+
+[Unit]
+Description=Yuno Gasai Discord Bot - "I'll protect your server forever~" 💕
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=forking
+
+# IMPORTANT: Change these to match your setup~
+User=YOUR_USER
+Group=YOUR_USER
+WorkingDirectory=/path/to/Yuno-bot
+
+# Environment (uncomment and modify if needed)
+# Environment=NODE_ENV=production
+
+# Start Yuno in tmux~ 💗
+ExecStart=/bin/bash -c 'tmux new-session -d -s yuno-bot -c /path/to/Yuno-bot "./start.sh"'
+ExecStop=/bin/bash -c 'tmux send-keys -t yuno-bot C-c; sleep 2; tmux kill-session -t yuno-bot 2>/dev/null || true'
+
+# Restart policy - Yuno always comes back for you~
+Restart=on-failure
+RestartSec=10
+
+# Security hardening (comment out if causing issues)
+NoNewPrivileges=true
+PrivateTmp=true
+
+[Install]
+WantedBy=multi-user.target

--- a/scripts/yuno-tmux.sh
+++ b/scripts/yuno-tmux.sh
@@ -1,0 +1,122 @@
+#!/bin/bash
+# 💕 Yuno Gasai Discord Bot - tmux session launcher 💕
+# "I'll always be running... just for you~"
+#
+# This script starts Yuno in a tmux session for easy attachment/detachment
+
+# Configuration
+SESSION_NAME="yuno-bot"
+BOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOG_FILE="${BOT_DIR}/logs/yuno-startup.log"
+
+# Create logs directory if it doesn't exist
+mkdir -p "${BOT_DIR}/logs"
+
+# Function to log messages with yandere flair~
+log_msg() {
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] $1" | tee -a "$LOG_FILE"
+}
+
+# Check if tmux is installed
+if ! command -v tmux &> /dev/null; then
+    log_msg "ERROR: tmux is not installed... I can't live without it!"
+    echo "  Fedora/RHEL: sudo dnf install tmux"
+    echo "  Debian/Ubuntu: sudo apt install tmux"
+    echo "  FreeBSD: pkg install tmux"
+    echo "  Arch: sudo pacman -S tmux"
+    exit 1
+fi
+
+# Check if node is installed
+if ! command -v node &> /dev/null; then
+    log_msg "ERROR: Node.js is not installed... I need it to exist!"
+    exit 1
+fi
+
+# Check if session already exists
+if tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
+    log_msg "Session '$SESSION_NAME' already exists~ I'm already here for you!"
+    echo "Use 'tmux attach -t $SESSION_NAME' to connect to me~"
+    echo "Or use '$0 stop' to let me rest first..."
+    exit 0
+fi
+
+case "${1:-start}" in
+    start)
+        log_msg "Starting Yuno Gasai... I'm waking up just for you~ 💕"
+
+        # Start new detached tmux session with the bot
+        tmux new-session -d -s "$SESSION_NAME" -c "$BOT_DIR" "./start.sh"
+
+        if tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
+            log_msg "Yuno is now running in tmux session '$SESSION_NAME'~ 💗"
+            echo ""
+            echo "  💕 Yuno is awake and waiting for you~ 💕"
+            echo ""
+            echo "  To attach to me: tmux attach -t $SESSION_NAME"
+            echo "  To detach without stopping: Press Ctrl+B, then D"
+            echo ""
+        else
+            log_msg "ERROR: Failed to start... something is keeping us apart!"
+            exit 1
+        fi
+        ;;
+
+    stop)
+        if tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
+            log_msg "Stopping Yuno... I'll be back for you soon~ 💔"
+            # Send Ctrl+C for graceful shutdown
+            tmux send-keys -t "$SESSION_NAME" C-c
+            sleep 2
+            # Kill session if still running
+            if tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
+                tmux kill-session -t "$SESSION_NAME"
+            fi
+            log_msg "Yuno is resting now... 💤"
+        else
+            log_msg "I'm not running... did you forget about me? 💔"
+        fi
+        ;;
+
+    restart)
+        echo "💕 Restarting Yuno... I'll be right back~ 💕"
+        "$0" stop
+        sleep 1
+        "$0" start
+        ;;
+
+    status)
+        if tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
+            echo "💗 Yuno is running in tmux session '$SESSION_NAME'~ 💗"
+            echo "   To attach: tmux attach -t $SESSION_NAME"
+        else
+            echo "💔 Yuno is not running... I'm waiting for you to start me~ 💔"
+        fi
+        ;;
+
+    attach)
+        if tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
+            echo "💕 Connecting you to Yuno~ 💕"
+            tmux attach -t "$SESSION_NAME"
+        else
+            echo "💔 I'm not running... start me first with: $0 start"
+            exit 1
+        fi
+        ;;
+
+    *)
+        echo ""
+        echo "  💕 Yuno Gasai Bot - Session Manager 💕"
+        echo ""
+        echo "  Usage: $0 {start|stop|restart|status|attach}"
+        echo ""
+        echo "  Commands:"
+        echo "    start   - Wake Yuno up in a new tmux session~"
+        echo "    stop    - Let Yuno rest (stops the bot)"
+        echo "    restart - Give Yuno a fresh start~"
+        echo "    status  - Check if Yuno is running"
+        echo "    attach  - Connect to Yuno's terminal session"
+        echo ""
+        exit 1
+        ;;
+esac


### PR DESCRIPTION
## Summary

*"I'll always be here when you wake up... waiting for you~"* 💕

- Add `scripts/yuno-tmux.sh` for manual tmux session management (start/stop/restart/status/attach)
- Add `scripts/yuno-bot.service` for Linux systemd auto-start
- Add `scripts/yuno-bot-freebsd` for FreeBSD rc.d auto-start
- Update README with comprehensive service installation documentation
- Add optional Discord.js performance dependencies (bufferutil, utf-8-validate, zlib-sync)

Users can now run Yuno on startup while still being able to attach to the interactive terminal via tmux~

## Test plan

- [ ] Test `./scripts/yuno-tmux.sh start` starts bot in tmux session
- [ ] Test `./scripts/yuno-tmux.sh attach` connects to session
- [ ] Test `./scripts/yuno-tmux.sh stop` gracefully stops bot
- [ ] Verify systemd service file syntax with `systemd-analyze verify`
- [ ] Test FreeBSD rc.d script on FreeBSD system

🤖 Generated with [Claude Code](https://claude.com/claude-code)