### PR TITLE
docs: Add comprehensive AGPL-3.0 license explanation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -781,9 +781,49 @@ Yuno can check for updates from git, download them, and apply them via hot-reloa
 
 ## 📜 License
 
-This project is licensed under the **GNU Affero General Public License v3.0**
+This project is licensed under the **GNU Affero General Public License v3.0 (AGPL-3.0)** 💕
 
-See the [LICENSE](LICENSE) file for details~ 💕
+### 💘 What This Means For You~
+
+*"I want to share everything with you... and everyone else too~"* 💗
+
+The AGPL-3.0 is a **copyleft license** that ensures this software remains free and open. Here's what you need to know:
+
+#### ✅ You CAN:
+- 💕 **Use** this bot for any purpose (personal, commercial, whatever~)
+- 🔧 **Modify** the code to your heart's content
+- 📤 **Distribute** copies to others
+- 🌐 **Run** it as a network service (like a public Discord bot)
+
+#### 📋 You MUST:
+- 📖 **Keep it open source** - ANY modifications you make must be released under AGPL-3.0
+- 🔗 **Publish your source code** - Your modified source code must be made publicly available
+- 📝 **State changes** - Document what you've modified from the original
+- 💌 **Include license** - Keep the LICENSE file and copyright notices intact
+
+#### 🌐 The Network Clause (This is the important part!):
+*"Even if we're apart... I'll always be connected to you~"* 💗
+
+Unlike regular GPL, **AGPL has a network provision**. This means:
+- If you modify this code **at all**, you must make your source public
+- Running a modified version as a network service (like a Discord bot) requires source disclosure
+- This applies whether you "distribute" the code or not - network use counts!
+- The `?source` command in this bot helps satisfy this requirement!
+
+#### ❌ You CANNOT:
+- 🚫 Make it closed source or keep modifications private
+- 🚫 Remove the license or copyright notices
+- 🚫 Use a different license for modified versions
+- 🚫 Run modified code without publishing your source
+
+#### 💡 In Simple Terms:
+> *"If you use my code to create something, you must share it with everyone too~ That's only fair, right?"* 💕
+
+This ensures that improvements to the bot benefit the entire community, not just one person. Yuno wants everyone to be happy~ 💗
+
+See the [LICENSE](LICENSE) file for the full legal text.
+
+**Source Code:** https://github.com/japaneseenrichmentorganization/Yuno-Gasai-2
 
 ---
 


### PR DESCRIPTION
## Summary

This PR adds a comprehensive explanation of what the AGPL-3.0 license means for users of this bot. The license section now clearly explains:

- **What you CAN do** - Use, modify, distribute, run as a network service
- **What you MUST do** - Keep open source, publish source code for ANY modifications, state changes, include license
- **The Network Clause** - Emphasizes that network use (like running a Discord bot) triggers source disclosure requirements even without traditional "distribution"
- **What you CANNOT do** - Close source, keep modifications private, remove notices, run modified code without publishing source

The explanation maintains the yandere-themed style consistent with the rest of the README while being accurate about AGPL requirements.

## Key Points

- AGPL requires source code to be public for **ANY** modifications, not just when distributing
- Network use (running as a Discord bot) counts as triggering the license requirements
- The \`?source\` command helps satisfy this requirement

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Confirm license explanation is accurate to AGPL-3.0 requirements