### PR TITLE
feat: Add field-level encryption for Node.js 24 native SQLite

### DIFF
--- a/DEFAULT_CONFIG.json
+++ b/DEFAULT_CONFIG.json
@@ -27,6 +27,11 @@
     "_comment": "Database encryption password. Requires @journeyapps/sqlcipher (npm install @journeyapps/sqlcipher). Leave null for no encryption.",
     "database.password": null,
 
+    "_comment": "Field-level encryption for sensitive data (works with native SQLite). Set to true and provide a key to enable.",
+    "database.fieldEncryption.enabled": false,
+    "_comment": "Field-level encryption key. Required if fieldEncryption is enabled. Use a strong passphrase.",
+    "database.fieldEncryption.key": null,
+
     "_comment": "Database performance optimizations. Enable based on your hosting situation.",
     "database.pragmas": {
         "_comment": "WAL mode improves concurrent read/write performance",

--- a/README.md
+++ b/README.md
@@ -416,6 +416,75 @@ You can also set encryption in `config.json`:
 }
 ```
 
+### 🔒 Field-Level Encryption (Node.js 24 Compatible)
+
+*"Even without SQLCipher, I'll keep your secrets safe~"* 💕
+
+If you're using **Node.js 24 native SQLite** (which doesn't support SQLCipher), you can use **field-level encryption** instead. This encrypts sensitive data using Node.js's built-in `crypto` module with AES-256-GCM.
+
+#### What Gets Encrypted
+
+| Data Type | Fields Encrypted |
+|-----------|-----------------|
+| Join messages | Message content, title |
+| Mention responses | Trigger, response, image URL |
+| Ban images | Image URLs |
+| DM inbox | Message content, attachments |
+| Bot bans | Ban reasons |
+| Mod actions | Action reasons |
+
+#### Configuration
+
+```json
+{
+    "database.fieldEncryption.enabled": true,
+    "database.fieldEncryption.key": "YourStrongPassphraseHere"
+}
+```
+
+#### Important Notes
+
+> ⚠️ **Security:**
+> - Use a strong passphrase (12+ characters recommended)
+> - **Keep your key safe!** Lost keys = lost data
+> - Key is stored in `config.json` - keep this file secure!
+
+> 💡 **Compatibility:**
+> - Works with Node.js 24 native SQLite
+> - Works alongside or instead of SQLCipher
+> - Backward compatible - existing unencrypted data remains readable
+> - New data will be encrypted automatically
+
+> 🔧 **Performance:**
+> - Small overhead for encrypt/decrypt operations
+> - Encrypted fields cannot be searched via SQL (by design)
+
+### 🔐 Alternative: VeraCrypt Volume Encryption
+
+*"Another way to keep everything locked away~"* 💕
+
+For full filesystem-level encryption, you can store your database on a **VeraCrypt encrypted volume**:
+
+1. Create a VeraCrypt encrypted container or partition
+2. Mount the volume and place your `yuno-2-database.db` inside
+3. Update `config.json` to point to the database path on the mounted volume:
+   ```json
+   {
+       "database": "/path/to/veracrypt/mount/yuno-2-database.db"
+   }
+   ```
+
+**Benefits:**
+- Encrypts the entire database file (not just specific fields)
+- Works with any SQLite implementation including native
+- All data is encrypted at rest when unmounted
+- No application-level changes needed
+
+**Considerations:**
+- Requires VeraCrypt to be installed and volume mounted before starting the bot
+- Database inaccessible when volume is unmounted
+- Manual mount/unmount process (can be scripted)
+
 ---
 
 ## 🚀 Node.js 24 Optimizations
@@ -454,7 +523,7 @@ npm run start:legacy
 | **Encrypted** | Install `@journeyapps/sqlcipher` | SQLCipher (supports encryption) |
 | **Legacy** | `npm run start:legacy` | sqlite3 npm package |
 
-> 💡 **Note:** Native SQLite doesn't support encryption. Use SQLCipher if you need database encryption.
+> 💡 **Note:** Native SQLite doesn't support database-level encryption. Use SQLCipher for full database encryption, or use field-level encryption (see above) for sensitive data protection with native SQLite.
 
 ---
 

--- a/src/lib/cryptoUtils.js
+++ b/src/lib/cryptoUtils.js
@@ -1,0 +1,146 @@
+/*
+    Yuno Gasai. A Discord.JS based bot, with multiple features.
+    Copyright (C) 2018 Maeeen <maeeennn@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see https://www.gnu.org/licenses/.
+*/
+
+/**
+ * Field-level encryption utilities using Node.js built-in crypto.
+ * Provides AES-256-GCM encryption for sensitive database fields.
+ *
+ * This is an alternative to SQLCipher when using Node.js 24 native SQLite,
+ * which doesn't support database-level encryption.
+ */
+
+const crypto = require('crypto');
+
+const ALGORITHM = 'aes-256-gcm';
+const IV_LENGTH = 16;
+const AUTH_TAG_LENGTH = 16;
+const SALT_LENGTH = 16;
+const KEY_ITERATIONS = 100000;
+
+/**
+ * Derives a 32-byte key from a passphrase using PBKDF2
+ * @param {string} passphrase - The passphrase to derive from
+ * @param {Buffer} salt - Salt for key derivation
+ * @returns {Buffer} 32-byte key
+ */
+function deriveKey(passphrase, salt) {
+    return crypto.pbkdf2Sync(passphrase, salt, KEY_ITERATIONS, 32, 'sha256');
+}
+
+/**
+ * Encrypts a string using AES-256-GCM
+ * @param {string|null} plaintext - The text to encrypt
+ * @param {string} passphrase - The encryption passphrase
+ * @returns {string|null} Base64 encoded encrypted data (salt + iv + authTag + ciphertext) or null
+ */
+function encrypt(plaintext, passphrase) {
+    if (plaintext === null || plaintext === undefined) {
+        return null;
+    }
+
+    const text = String(plaintext);
+    const salt = crypto.randomBytes(SALT_LENGTH);
+    const key = deriveKey(passphrase, salt);
+    const iv = crypto.randomBytes(IV_LENGTH);
+
+    const cipher = crypto.createCipheriv(ALGORITHM, key, iv);
+    const encrypted = Buffer.concat([cipher.update(text, 'utf8'), cipher.final()]);
+    const authTag = cipher.getAuthTag();
+
+    // Format: salt (16) + iv (16) + authTag (16) + ciphertext
+    const result = Buffer.concat([salt, iv, authTag, encrypted]);
+    return result.toString('base64');
+}
+
+/**
+ * Decrypts a string encrypted with encrypt()
+ * @param {string|null} encryptedData - Base64 encoded encrypted data
+ * @param {string} passphrase - The encryption passphrase
+ * @returns {string|null} Decrypted plaintext or original value if decryption fails
+ */
+function decrypt(encryptedData, passphrase) {
+    if (encryptedData === null || encryptedData === undefined) {
+        return null;
+    }
+
+    try {
+        const buffer = Buffer.from(encryptedData, 'base64');
+
+        // Minimum size check: salt (16) + iv (16) + authTag (16) + at least 1 byte ciphertext
+        if (buffer.length < 49) {
+            // Too short to be encrypted data, return as-is (legacy unencrypted data)
+            return encryptedData;
+        }
+
+        const salt = buffer.slice(0, SALT_LENGTH);
+        const iv = buffer.slice(SALT_LENGTH, SALT_LENGTH + IV_LENGTH);
+        const authTag = buffer.slice(SALT_LENGTH + IV_LENGTH, SALT_LENGTH + IV_LENGTH + AUTH_TAG_LENGTH);
+        const ciphertext = buffer.slice(SALT_LENGTH + IV_LENGTH + AUTH_TAG_LENGTH);
+
+        const key = deriveKey(passphrase, salt);
+
+        const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
+        decipher.setAuthTag(authTag);
+
+        const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
+        return decrypted.toString('utf8');
+    } catch (err) {
+        // If decryption fails, it might be unencrypted legacy data
+        // Return the original value
+        return encryptedData;
+    }
+}
+
+/**
+ * Checks if a value appears to be encrypted (base64 with correct minimum length)
+ * @param {string} value - Value to check
+ * @returns {boolean}
+ */
+function isEncrypted(value) {
+    if (typeof value !== 'string') return false;
+    try {
+        const buffer = Buffer.from(value, 'base64');
+        // Minimum size: salt (16) + iv (16) + authTag (16) + 1 (min ciphertext)
+        return buffer.length >= 49;
+    } catch {
+        return false;
+    }
+}
+
+/**
+ * Creates an encryption helper bound to a specific passphrase
+ * @param {string|null} passphrase - The encryption passphrase (null to disable)
+ * @returns {Object} Object with encrypt and decrypt methods
+ */
+function createEncryptionHelper(passphrase) {
+    const enabled = passphrase !== null && passphrase !== undefined && passphrase.length > 0;
+
+    return {
+        enabled,
+        encrypt: enabled ? (value) => encrypt(value, passphrase) : (value) => value,
+        decrypt: enabled ? (value) => decrypt(value, passphrase) : (value) => value
+    };
+}
+
+module.exports = {
+    encrypt,
+    decrypt,
+    isEncrypted,
+    deriveKey,
+    createEncryptionHelper
+};


### PR DESCRIPTION
## Summary

Adds AES-256-GCM field-level encryption using Node.js built-in `crypto` module as an alternative to SQLCipher when using Node.js 24 native SQLite.

### What This Solves

Node.js 24's native SQLite doesn't support SQLCipher, leaving users without encryption options. This PR provides field-level encryption that:
- Works with native SQLite (no external dependencies)
- Encrypts sensitive data at rest
- Is backward compatible with existing unencrypted data

### Changes

- **New file:** `src/lib/cryptoUtils.js` - AES-256-GCM encryption utilities with PBKDF2 key derivation
- **Updated:** `src/database.js` - Added `encrypt()`/`decrypt()` methods to both NativeDatabase and LegacyDatabase classes
- **Updated:** `src/DatabaseCommands.js` - Encrypt/decrypt sensitive fields:
  - Join DM messages and titles
  - Mention response triggers, responses, and images
  - Ban images
  - DM inbox content and attachments
  - Bot ban and mod action reasons
- **Updated:** `DEFAULT_CONFIG.json` - Added `database.fieldEncryption.enabled` and `database.fieldEncryption.key`
- **Updated:** `src/Yuno.js` - Wired up field encryption configuration
- **Updated:** `README.md` - Documentation for field-level encryption and VeraCrypt alternative

### Configuration

```json
{
    "database.fieldEncryption.enabled": true,
    "database.fieldEncryption.key": "YourStrongPassphraseHere"
}
```

### Security Features

- AES-256-GCM authenticated encryption
- PBKDF2 key derivation with 100,000 iterations
- Unique salt and IV per encrypted value
- Graceful fallback for unencrypted legacy data

## Test plan

- [ ] Enable field encryption and verify bot starts successfully
- [ ] Create mention responses and verify they're encrypted in the database
- [ ] Restart bot and verify mention responses are decrypted correctly
- [ ] Test with existing unencrypted database (backward compatibility)
- [ ] Verify error when encryption enabled but no key provided

🤖 Generated with [Claude Code](https://claude.com/claude-code)