### PR TITLE
Add low-memory mode for Pi/embedded systems

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -28,11 +28,12 @@ NODE_OPTIONS="$NODE_OPTIONS --max-old-space-size=2048"
 # === GARBAGE COLLECTION ===
 # More aggressive GC for low-memory systems (reduces memory spikes)
 # Uncomment for Pi/embedded systems:
-NODE_OPTIONS="$NODE_OPTIONS --gc-interval=100"
+GC_OPTIONS="--gc-interval=100"
 
 # === NOTES ===
 # If running on Pi with presence logging enabled, also set in config.json:
 #   "activityLogger.lowMemoryMode": true
 # This enables buffer limits and automatic cleanup of stale data.
 
-exec node $NODE_OPTIONS index.js "$@"
+export NODE_OPTIONS
+exec node $GC_OPTIONS index.js "$@"


### PR DESCRIPTION
## Summary
- Add low-memory mode configuration for activity logger with buffer limits and automatic cleanup
- Update start.sh with memory configuration options for different system sizes (Pi 3/4, embedded, servers)
- Fix `--gc-interval` flag by passing it directly to node instead of via NODE_OPTIONS (V8 flags not allowed in NODE_OPTIONS)
- Update .gitignore to exclude database files and local config

## Test plan
- [ ] Verify bot starts without NODE_OPTIONS error on Node.js 24
- [ ] Test on low-memory system with `activityLogger.lowMemoryMode: true`
- [ ] Confirm memory limits are respected with `--max-old-space-size`

🤖 Generated with [Claude Code](https://claude.com/claude-code)