### PR TITLE
fix: Handle BigInt userID in fix-xp-data command

### DIFF
--- a/src/commands/fix-xp-data.js
+++ b/src/commands/fix-xp-data.js
@@ -28,8 +28,9 @@ module.exports.run = async function(yuno, author, args, msg) {
 
     try {
         // Query all XP records for this guild
+        // Cast userID to TEXT to avoid BigInt issues with Node.js 24 native SQLite
         const allXPData = await yuno.database.allPromise(
-            "SELECT userID, exp, level FROM experiences WHERE guildID = ?",
+            "SELECT CAST(userID AS TEXT) as userID, exp, level FROM experiences WHERE guildID = ?",
             [msg.guild.id]
         );
 


### PR DESCRIPTION
## Summary
- Fixes `fix-xp-data` command crashing with BigInt error on Node.js 24 native SQLite

## Problem
```
RangeError: Value is too large to be represented as a JavaScript number: 239882051166142465
```

Node.js 24's native SQLite returns `BigInt` for INTEGER columns that exceed JavaScript's safe integer limit (2^53). Discord user IDs are larger than this limit.

## Fix
Cast `userID` to TEXT in the SQL query to avoid the BigInt conversion issue.

## Test plan
- [ ] Run `.fix-xp-data` on a guild with XP data
- [ ] Verify no BigInt error occurs

🤖 Generated with [Claude Code](https://claude.com/claude-code)