### PR TITLE
fix: Disable Turbofan JIT on ARM to prevent SIGILL crashes

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -30,10 +30,21 @@ NODE_OPTIONS="$NODE_OPTIONS --max-old-space-size=2048"
 # Uncomment for Pi/embedded systems:
 GC_OPTIONS="--gc-interval=100"
 
+# === ARM/FreeBSD FIX ===
+# Disable Turbofan JIT optimizer - it generates illegal instructions on ARM FreeBSD
+# This prevents SIGILL crashes (signal 4)
+ARCH=$(uname -m)
+if [[ "$ARCH" == "aarch64" || "$ARCH" == "arm64" || "$ARCH" == "armv"* ]]; then
+    ARM_FIX="--no-turbofan"
+    echo "Detected ARM architecture ($ARCH) - disabling Turbofan JIT"
+else
+    ARM_FIX=""
+fi
+
 # === NOTES ===
 # If running on Pi with presence logging enabled, also set in config.json:
 #   "activityLogger.lowMemoryMode": true
 # This enables buffer limits and automatic cleanup of stale data.
 
 export NODE_OPTIONS
-exec node $GC_OPTIONS index.js "$@"
+exec node $GC_OPTIONS $ARM_FIX index.js "$@"


### PR DESCRIPTION
## Summary
- Adds architecture detection to `start.sh` to identify ARM CPUs
- Automatically disables V8's Turbofan JIT optimizer on ARM systems with `--no-turbofan`
- Preserves full JIT performance on x86/amd64 systems

## Problem
V8's Turbofan JIT compiler generates illegal ARM instructions on FreeBSD/ARM64 (Raspberry Pi 4 with Cortex-A72), causing the bot to crash with signal 4 (SIGILL - Illegal Instruction).

## Test plan
- [x] Verified fix on Raspberry Pi 4 running FreeBSD 15.0 ARM64
- [x] Bot runs stably without SIGILL crashes after applying `--no-turbofan`
- [ ] Verify x86 systems are unaffected (ARM_FIX should be empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)