### PR TITLE
fix: Make start.sh POSIX sh compatible

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Yuno Gasai 2 - Production Startup Script
 # Requires Node.js 24.0.0 or higher
@@ -34,12 +34,15 @@ GC_OPTIONS="--gc-interval=100"
 # Disable Turbofan JIT optimizer - it generates illegal instructions on ARM FreeBSD
 # This prevents SIGILL crashes (signal 4)
 ARCH=$(uname -m)
-if [[ "$ARCH" == "aarch64" || "$ARCH" == "arm64" || "$ARCH" == "armv"* ]]; then
-    ARM_FIX="--no-turbofan"
-    echo "Detected ARM architecture ($ARCH) - disabling Turbofan JIT"
-else
-    ARM_FIX=""
-fi
+case "$ARCH" in
+    aarch64|arm64|armv*)
+        ARM_FIX="--no-turbofan"
+        echo "Detected ARM architecture ($ARCH) - disabling Turbofan JIT"
+        ;;
+    *)
+        ARM_FIX=""
+        ;;
+esac
 
 # === NOTES ===
 # If running on Pi with presence logging enabled, also set in config.json:


### PR DESCRIPTION
## Summary
- Changes shebang from `#!/bin/bash` to `#!/bin/sh`
- Replaces bash-specific `[[ ]]` syntax with POSIX `case` statement for architecture detection

## Problem
Running `sh start.sh` produced errors on FreeBSD:
```
start.sh: [[: not found
start.sh: arm64: not found
```

## Test plan
- [x] Verified script runs correctly with `sh start.sh`
- [x] ARM detection works: `Detected ARM architecture (arm64) - disabling Turbofan JIT`
- [x] Bot starts successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)