### PR TITLE
feat: add adaptive DM rate limiting and spam detection

### DIFF
--- a/DEFAULT_CONFIG.json
+++ b/DEFAULT_CONFIG.json
@@ -58,6 +58,10 @@
     "_comment": "The number of warnings before a ban (when spamming)",
     "spam.max-warnings": 3,
 
+    "_comment": "DM rate limiting. Adaptively drops messages from users sending too fast. spamAction: 'ignore' (1-hour temp block) or 'ban' (permanent bot-ban).",
+    "dm-rate-limit.enabled": true,
+    "dm-rate-limit.spamAction": "ignore",
+
     "_comment": "Number of experience given per msg",
     "chat.exppermsg": 20,
 

--- a/README.md
+++ b/README.md
@@ -932,6 +932,7 @@ Yuno can check for updates from git, download them, and apply them via hot-reloa
 | `bot-banlist` | *"The ones I've cast aside..."* 📋 |
 | `alt-detector` | *"I can always tell when someone's pretending~"* 🔍 |
 | `scan-alts` | *"Let me check everyone for fakes~"* 🕵️ |
+| `dm-rate-limit` | *"Don't message me too fast~"* 🛡️ |
 
 ### 💻 Terminal-Only Commands
 

--- a/src/commands/dm-rate-limit.js
+++ b/src/commands/dm-rate-limit.js
@@ -101,7 +101,7 @@ module.exports.about = {
     "terminal": false,
     "list": true,
     "listTerminal": false,
-    "requiredPermissions": ["ManageGuild"],
+    "onlyMasterUsers": true,
     "aliases": ["dmratelimit", "dmrl"],
     "dangerous": false
 };

--- a/src/commands/dm-rate-limit.js
+++ b/src/commands/dm-rate-limit.js
@@ -1,0 +1,107 @@
+/*
+    Yuno Gasai. A Discord.JS based bot, with multiple features.
+    Copyright (C) 2018 Maeeen <maeeennn@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see https://www.gnu.org/licenses/.
+*/
+
+delete require.cache[require.resolve("../lib/EmbedCmdResponse")];
+const EmbedCmdResponse = require("../lib/EmbedCmdResponse");
+
+const VALID_ACTIONS = ["ignore", "ban"];
+
+module.exports.run = async function(yuno, author, args, msg) {
+    const sub = args[0]?.toLowerCase();
+
+    if (!sub || sub === "status") {
+        const enabled = yuno.config.get("dm-rate-limit.enabled") !== false;
+        const spamAction = yuno.config.get("dm-rate-limit.spamAction") || "ignore";
+
+        return msg.channel.send({ embeds: [new EmbedCmdResponse()
+            .setColor("#5865F2")
+            .setTitle(":mailbox_with_mail: DM Rate Limit Status")
+            .addFields(
+                { name: "Status", value: enabled ? ":green_circle: **Enabled**" : ":red_circle: **Disabled**", inline: true },
+                { name: "Spam Action", value: `\`${spamAction}\``, inline: true },
+                { name: "How it works", value:
+                    "Each user gets a randomized message limit (6–10 msg/60s).\n" +
+                    "The limit **tightens** for every dropped message.\n" +
+                    "After **5 dropped messages** with no human reply → spam action fires.\n" +
+                    "Human replies (via `reply` command) grant **leniency** for 10 minutes."
+                }
+            )
+            .setCMDRequester(msg.member)
+        ]});
+    }
+
+    if (sub === "enable") {
+        yuno.config.set("dm-rate-limit.enabled", true).save();
+        return msg.channel.send({ embeds: [new EmbedCmdResponse()
+            .setColor("#43cc24")
+            .setTitle(":white_check_mark: DM Rate Limiting Enabled")
+            .setDescription("Adaptive DM rate limiting is now **enabled**.")
+            .setCMDRequester(msg.member)
+        ]});
+    }
+
+    if (sub === "disable") {
+        yuno.config.set("dm-rate-limit.enabled", false).save();
+        return msg.channel.send({ embeds: [new EmbedCmdResponse()
+            .setColor("#ff6600")
+            .setTitle(":octagonal_sign: DM Rate Limiting Disabled")
+            .setDescription("DM rate limiting is now **disabled**.")
+            .setCMDRequester(msg.member)
+        ]});
+    }
+
+    if (sub === "set-action") {
+        const action = args[1]?.toLowerCase();
+        if (!action || !VALID_ACTIONS.includes(action)) {
+            return msg.channel.send(`:negative_squared_cross_mark: Invalid action. Valid: \`${VALID_ACTIONS.join(", ")}\``);
+        }
+        yuno.config.set("dm-rate-limit.spamAction", action).save();
+        const desc = action === "ban"
+            ? "Spam users will be **permanently bot-banned** automatically."
+            : "Spam users will be **temp-blocked for 1 hour** (resets on restart).";
+        return msg.channel.send({ embeds: [new EmbedCmdResponse()
+            .setColor("#43cc24")
+            .setTitle(":white_check_mark: Spam Action Updated")
+            .setDescription(`Spam action set to \`${action}\`. ${desc}`)
+            .setCMDRequester(msg.member)
+        ]});
+    }
+
+    return msg.channel.send(
+        `:negative_squared_cross_mark: Unknown subcommand \`${sub}\`. Valid: \`enable\`, \`disable\`, \`set-action\`, \`status\``
+    );
+};
+
+module.exports.about = {
+    "command": "dm-rate-limit",
+    "description": "Configure DM rate limiting and spam detection. Subcommands: enable, disable, set-action, status",
+    "examples": [
+        "dm-rate-limit status",
+        "dm-rate-limit enable",
+        "dm-rate-limit disable",
+        "dm-rate-limit set-action ignore",
+        "dm-rate-limit set-action ban"
+    ],
+    "discord": true,
+    "terminal": false,
+    "list": true,
+    "listTerminal": false,
+    "requiredPermissions": ["ManageGuild"],
+    "aliases": ["dmratelimit", "dmrl"],
+    "dangerous": false
+};

--- a/src/commands/reply.js
+++ b/src/commands/reply.js
@@ -104,6 +104,12 @@ module.exports.runTerminal = async function(yuno, args, rawInput, rl) {
 
         console.log(`Successfully sent DM to ${user.tag}`);
 
+        // Notify dm-handler rate limiter that a human replied (grants leniency window)
+        const dmHandlerMod = yuno.modules.find(m => m.modulename === "dm-handler");
+        if (dmHandlerMod?.notifyHumanReply) {
+            dmHandlerMod.notifyHumanReply(userId);
+        }
+
         // Mark inbox message as replied if we have an inbox ID
         if (inboxId) {
             await yuno.dbCommands.markDmReplied(yuno.database, inboxId);

--- a/src/modules/dm-handler.js
+++ b/src/modules/dm-handler.js
@@ -113,6 +113,9 @@ async function executeSpamAction(userId) {
         userRateCache.set(userId, state);
     }
 
+    // Always apply in-memory temp block as an immediate backstop
+    tempBlockList.set(userId, true);
+
     const spamAction = (yunoInstance.config.get("dm-rate-limit.spamAction") || "ignore").toLowerCase();
 
     if (spamAction === "ban") {
@@ -129,11 +132,9 @@ async function executeSpamAction(userId) {
                 yunoInstance.prompt.warn(`[DM Rate Limit] Auto-banned ${userId} for DM spam`);
             }
         } catch (e) {
-            yunoInstance.prompt.error(`[DM Rate Limit] Failed to auto-ban ${userId}: ${e.message}`);
+            yunoInstance.prompt.error(`[DM Rate Limit] Failed to auto-ban ${userId}, temp block applied: ${e.message}`);
         }
     } else {
-        // "ignore" — temp block for 1 hour
-        tempBlockList.set(userId, true); // value is irrelevant; TTL handles expiry
         yunoInstance.prompt.warn(`[DM Rate Limit] Temp-blocked ${userId} for 1 hour (DM spam)`);
     }
 }
@@ -367,8 +368,17 @@ module.exports.configLoaded = function() {};
  * @param {string} userId
  */
 module.exports.notifyHumanReply = function(userId) {
-    const state = userRateCache.get(userId);
-    if (!state) return; // no active session for this user, nothing to update
+    let state = userRateCache.get(userId);
+    if (!state) {
+        // No active session; create one to preserve the reply leniency for their next message
+        state = {
+            messages: [],
+            baseLimit: 6 + Math.floor(Math.random() * 5),
+            droppedCount: 0,
+            lastHumanReply: 0,
+            spamActionTaken: false
+        };
+    }
     state.lastHumanReply = Date.now();
     userRateCache.set(userId, state);
 };

--- a/src/modules/dm-handler.js
+++ b/src/modules/dm-handler.js
@@ -19,6 +19,17 @@
 module.exports.modulename = "dm-handler";
 
 const { EmbedBuilder } = require("discord.js");
+const LRUCache = require("../lib/lruCache");
+
+// Per-user rate limit state. TTL of 5 min = state re-randomizes after 5 min of silence.
+const userRateCache = new LRUCache(2000, 5 * 60 * 1000);
+
+// Temporary block list for "ignore" spam action: userId -> unblockTimestamp
+const tempBlockList = new Map();
+
+const RATE_WINDOW_MS = 60 * 1000;               // 60-second sliding window
+const HUMAN_REPLY_LENIENCY_MS = 10 * 60 * 1000; // +5 boost lasts 10 min after reply
+const SPAM_DROP_THRESHOLD = 5;                   // dropped messages before spam action fires
 
 let DISCORD_EVENTED = false,
     discClient = null,
@@ -27,6 +38,103 @@ let DISCORD_EVENTED = false,
 
 // Rate limit tracking for DM forwarding
 const rateLimitState = new Map();
+
+/**
+ * Get or create per-user rate limit state.
+ * baseLimit is randomized per session (re-randomizes on TTL expiry).
+ */
+function getOrCreateState(userId) {
+    let state = userRateCache.get(userId);
+    if (!state) {
+        state = {
+            messages: [],                                   // timestamps in current window
+            baseLimit: 6 + Math.floor(Math.random() * 5),  // jittered: 6-10
+            droppedCount: 0,                                // messages dropped this session
+            lastHumanReply: 0,                              // timestamp of last human reply
+            spamActionTaken: false
+        };
+    }
+    return state;
+}
+
+/**
+ * Check if a new message from userId is allowed. Records it if so.
+ * Returns true = allowed, false = rate limited (silently drop).
+ */
+function checkAndRecord(userId) {
+    const now = Date.now();
+    const state = getOrCreateState(userId);
+
+    // Prune messages outside the sliding window
+    state.messages = state.messages.filter(t => now - t < RATE_WINDOW_MS);
+
+    // Adaptive effective limit: tightens by 1 for each previously dropped message
+    let effectiveLimit = Math.max(2, state.baseLimit - state.droppedCount);
+
+    // Leniency boost if a human has replied recently
+    if (now - state.lastHumanReply < HUMAN_REPLY_LENIENCY_MS) {
+        effectiveLimit += 5;
+    }
+
+    if (state.messages.length >= effectiveLimit) {
+        state.droppedCount++;
+        userRateCache.set(userId, state); // TTL reset = "5 min from last message"
+        return false;
+    }
+
+    state.messages.push(now);
+    userRateCache.set(userId, state);
+    return true;
+}
+
+/**
+ * Returns true if the user has crossed the spam threshold and no human has
+ * replied recently. Only fires once per session (spamActionTaken guard).
+ */
+function isSpam(userId) {
+    const state = userRateCache.get(userId);
+    if (!state || state.spamActionTaken) return false;
+    const recentReply = (Date.now() - state.lastHumanReply) < HUMAN_REPLY_LENIENCY_MS;
+    return state.droppedCount >= SPAM_DROP_THRESHOLD && !recentReply;
+}
+
+/**
+ * Execute the configured spam action for a user.
+ * "ignore" = 1-hour temp block (in-memory).
+ * "ban"    = permanent bot-ban via existing addBotBan().
+ */
+async function executeSpamAction(userId) {
+    // Mark as actioned to prevent repeat
+    const state = userRateCache.get(userId);
+    if (state) {
+        state.spamActionTaken = true;
+        userRateCache.set(userId, state);
+    }
+
+    const spamAction = (yunoInstance.config.get("dm-rate-limit.spamAction") || "ignore").toLowerCase();
+
+    if (spamAction === "ban") {
+        try {
+            const alreadyBanned = await yunoInstance.dbCommands.isBotBanned(yunoInstance.database, userId, null);
+            if (!alreadyBanned.banned) {
+                await yunoInstance.dbCommands.addBotBan(
+                    yunoInstance.database,
+                    userId,
+                    "user",
+                    "Automatic ban: DM spam detected",
+                    "auto-rate-limit"
+                );
+                yunoInstance.prompt.warn(`[DM Rate Limit] Auto-banned ${userId} for DM spam`);
+            }
+        } catch (e) {
+            yunoInstance.prompt.error(`[DM Rate Limit] Failed to auto-ban ${userId}: ${e.message}`);
+        }
+    } else {
+        // "ignore" — temp block for 1 hour
+        tempBlockList.set(userId, Date.now() + 60 * 60 * 1000);
+        yunoInstance.prompt.warn(`[DM Rate Limit] Temp-blocked ${userId} for 1 hour (DM spam)`);
+    }
+}
 
 /**
  * Format timestamp for display
@@ -137,6 +245,27 @@ async function onMessage(message) {
     if (message.author.bot) return;
 
     const user = message.author;
+    const userId = user.id;
+
+    // --- Adaptive rate limiting ---
+    const rateLimitEnabled = yunoInstance?.config?.get("dm-rate-limit.enabled");
+    if (rateLimitEnabled !== false) {
+        // Check in-memory temp block list
+        const tempBlockExpiry = tempBlockList.get(userId);
+        if (tempBlockExpiry) {
+            if (Date.now() < tempBlockExpiry) return; // still blocked
+            tempBlockList.delete(userId);             // expired, clean up
+        }
+
+        const allowed = checkAndRecord(userId);
+        if (!allowed) {
+            if (isSpam(userId)) {
+                await executeSpamAction(userId);
+            }
+            return; // silently drop
+        }
+    }
+    // --- End rate limiting ---
 
     try {
         // Check if user is bot-banned
@@ -234,8 +363,21 @@ module.exports.init = async function(Yuno, hotReloaded) {
 
 module.exports.configLoaded = function() {};
 
+/**
+ * Called by the reply command when a human sends a reply to a user.
+ * Grants the user leniency in the adaptive rate limiter for 10 minutes.
+ * @param {string} userId
+ */
+module.exports.notifyHumanReply = function(userId) {
+    const state = getOrCreateState(userId);
+    state.lastHumanReply = Date.now();
+    userRateCache.set(userId, state);
+};
+
 module.exports.beforeShutdown = async function(Yuno) {
     rateLimitState.clear();
+    tempBlockList.clear();
+    userRateCache.clear();
 
     if (discClient && messageHandler) {
         discClient.removeListener("messageCreate", messageHandler);

--- a/src/modules/dm-handler.js
+++ b/src/modules/dm-handler.js
@@ -24,8 +24,8 @@ const LRUCache = require("../lib/lruCache");
 // Per-user rate limit state. TTL of 5 min = state re-randomizes after 5 min of silence.
 const userRateCache = new LRUCache(2000, 5 * 60 * 1000);
 
-// Temporary block list for "ignore" spam action: userId -> unblockTimestamp
-const tempBlockList = new Map();
+// Temporary block list for "ignore" spam action: bounded LRU with 1-hour TTL
+const tempBlockList = new LRUCache(1000, 60 * 60 * 1000); // 1-hour TTL, max 1000 entries
 
 const RATE_WINDOW_MS = 60 * 1000;               // 60-second sliding window
 const HUMAN_REPLY_LENIENCY_MS = 10 * 60 * 1000; // +5 boost lasts 10 min after reply
@@ -104,6 +104,8 @@ function isSpam(userId) {
  * "ban"    = permanent bot-ban via existing addBotBan().
  */
 async function executeSpamAction(userId) {
+    if (!yunoInstance) return; // guard against pre-init calls
+
     // Mark as actioned to prevent repeat
     const state = userRateCache.get(userId);
     if (state) {
@@ -131,7 +133,7 @@ async function executeSpamAction(userId) {
         }
     } else {
         // "ignore" — temp block for 1 hour
-        tempBlockList.set(userId, Date.now() + 60 * 60 * 1000);
+        tempBlockList.set(userId, true); // value is irrelevant; TTL handles expiry
         yunoInstance.prompt.warn(`[DM Rate Limit] Temp-blocked ${userId} for 1 hour (DM spam)`);
     }
 }
@@ -251,11 +253,7 @@ async function onMessage(message) {
     const rateLimitEnabled = yunoInstance?.config?.get("dm-rate-limit.enabled");
     if (rateLimitEnabled !== false) {
         // Check in-memory temp block list
-        const tempBlockExpiry = tempBlockList.get(userId);
-        if (tempBlockExpiry) {
-            if (Date.now() < tempBlockExpiry) return; // still blocked
-            tempBlockList.delete(userId);             // expired, clean up
-        }
+        if (tempBlockList.has(userId)) return; // LRU TTL handles 1-hour expiry
 
         const allowed = checkAndRecord(userId);
         if (!allowed) {
@@ -369,7 +367,8 @@ module.exports.configLoaded = function() {};
  * @param {string} userId
  */
 module.exports.notifyHumanReply = function(userId) {
-    const state = getOrCreateState(userId);
+    const state = userRateCache.get(userId);
+    if (!state) return; // no active session for this user, nothing to update
     state.lastHumanReply = Date.now();
     userRateCache.set(userId, state);
 };


### PR DESCRIPTION
## Summary

- Adds per-user adaptive DM rate limiting to `dm-handler.js` — each user gets a randomized message limit (6–10 msg/60s) that tightens by 1 for every dropped message, making it hard to calibrate a bot to bypass
- When 5+ messages are dropped with no recent human reply, a configurable spam action fires: 1-hour in-memory temp-block (`ignore`) or permanent bot-ban (`ban`)
- Human replies via the `reply` terminal command grant a 10-minute leniency window, preserving legitimate conversations
- Adds `dm-rate-limit` command (master users only) to enable/disable and configure the spam action
- All state is in-memory (no DB schema changes); tracking uses the existing `LRUCache` with bounded sizes and TTLs

## Test Plan

- [ ] Bot starts cleanly, `dm-handler` module loads without errors
- [ ] `.dm-rate-limit status` shows correct defaults (enabled, action: ignore)
- [ ] `.dm-rate-limit set-action ban` / `ignore` updates and persists across restart
- [ ] `.dm-rate-limit enable` / `disable` toggles the feature
- [ ] Sending many DMs rapidly gets silently dropped after the randomized limit
- [ ] After 5+ dropped messages, spam action fires (temp-block or ban depending on config)
- [ ] Using `reply <id>` in the terminal grants the user leniency (messages flow again)
- [ ] Non-master users cannot use `.dm-rate-limit` (onlyMasterUsers: true)

🤖 Generated with [Claude Code](https://claude.com/claude-code)