### PR TITLE
feat: add image checksum and nsfw repeat-text spam rules

### DIFF
--- a/src/DatabaseCommands.js
+++ b/src/DatabaseCommands.js
@@ -231,6 +231,12 @@ module.exports = self = {
                 actionSuspicious TEXT DEFAULT 'log',
                 actionHighlySuspicious TEXT DEFAULT 'log',
                 actionMegaSuspicious TEXT DEFAULT 'ban'
+            )`),
+            database.runPromise(`CREATE TABLE IF NOT EXISTS spamChecksums (
+                checksum   TEXT NOT NULL,
+                guildId    TEXT NOT NULL,
+                detectedAt INTEGER,
+                PRIMARY KEY (checksum, guildId)
             )`)
         ]);
 
@@ -247,7 +253,8 @@ module.exports = self = {
             database.runPromise(`CREATE INDEX IF NOT EXISTS idx_mentionresponses_gid_trigger ON mentionResponses(gid, trigger)`),
             database.runPromise(`CREATE INDEX IF NOT EXISTS idx_banimages_gid_banner ON banImages(gid, banner)`),
             database.runPromise(`CREATE INDEX IF NOT EXISTS idx_logchannels_gid ON logChannels(gid)`),
-            database.runPromise(`CREATE INDEX IF NOT EXISTS idx_vcsessions_gid ON vcSessions(gid)`)
+            database.runPromise(`CREATE INDEX IF NOT EXISTS idx_vcsessions_gid ON vcSessions(gid)`),
+            database.runPromise(`CREATE INDEX IF NOT EXISTS idx_spamchecksums_guildid ON spamChecksums(guildId)`)
         ]);
     },
 
@@ -1711,5 +1718,36 @@ module.exports = self = {
             await database.runPromise("INSERT INTO altDetectorConfig(gid) VALUES(?)", [guildId]);
         }
         await database.runPromise(`UPDATE altDetectorConfig SET ${field} = ? WHERE gid = ?`, [value, guildId]);
+    }
+    ,
+
+    // ==================== Spam Checksum Functions ====================
+
+    /**
+     * Check if a checksum is already known as spam for this guild.
+     * @param {Database} database
+     * @param {string} checksum - SHA-256 hex digest
+     * @param {string} guildId
+     * @returns {Promise<boolean>}
+     */
+    "isKnownSpamChecksum": async function(database, checksum, guildId) {
+        const rows = await database.allPromise(
+            "SELECT 1 FROM spamChecksums WHERE checksum = ? AND guildId = ?",
+            [checksum, guildId]
+        );
+        return rows.length > 0;
+    },
+
+    /**
+     * Store a checksum as known spam for this guild (INSERT OR IGNORE).
+     * @param {Database} database
+     * @param {string} checksum - SHA-256 hex digest
+     * @param {string} guildId
+     */
+    "addSpamChecksum": async function(database, checksum, guildId) {
+        await database.runPromise(
+            "INSERT OR IGNORE INTO spamChecksums(checksum, guildId, detectedAt) VALUES(?, ?, ?)",
+            [checksum, guildId, Date.now()]
+        );
     }
 }

--- a/src/DatabaseCommands.js
+++ b/src/DatabaseCommands.js
@@ -1718,8 +1718,7 @@ module.exports = self = {
             await database.runPromise("INSERT INTO altDetectorConfig(gid) VALUES(?)", [guildId]);
         }
         await database.runPromise(`UPDATE altDetectorConfig SET ${field} = ? WHERE gid = ?`, [value, guildId]);
-    }
-    ,
+    },
 
     // ==================== Spam Checksum Functions ====================
 

--- a/src/message-processors/custom-spam-rules/447665600135823361.js
+++ b/src/message-processors/custom-spam-rules/447665600135823361.js
@@ -68,6 +68,84 @@ function pruneHistory(state) {
     }
 }
 
+const MAX_IMAGE_BYTES = 4 * 1024 * 1024; // 4 MB hard cap per image
+
+/**
+ * Download an image URL into a Buffer.
+ * Returns null on error, timeout, or if the file exceeds MAX_IMAGE_BYTES.
+ */
+async function downloadImage(url) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), 10000); // 10s timeout
+    try {
+        const res = await fetch(url, { signal: controller.signal });
+        if (!res.ok) return null;
+        const len = parseInt(res.headers.get("content-length") || "0", 10);
+        if (len > MAX_IMAGE_BYTES) return null;
+        const buf = Buffer.from(await res.arrayBuffer());
+        if (buf.length > MAX_IMAGE_BYTES) return null;
+        return buf;
+    } catch {
+        return null;
+    } finally {
+        clearTimeout(timer);
+    }
+}
+
+/**
+ * Non-blocking image checksum processor.
+ * Called fire-and-forget from the image-checksum rule action.
+ */
+async function processImageChecksums(msg) {
+    if (!yunoRef || !msg.member) return;
+
+    const imageAttachments = [...msg.attachments.values()].filter(
+        a => a.contentType?.startsWith("image/")
+    );
+
+    for (const attachment of imageAttachments) {
+        const buf = await downloadImage(attachment.url);
+        if (!buf) continue;
+
+        const checksum = crypto.createHash("sha256").update(buf).digest("hex");
+        const guildId = msg.guild.id;
+
+        // Fast path: known spam checksum in DB
+        const isKnown = await yunoRef.dbCommands.isKnownSpamChecksum(
+            yunoRef.database, checksum, guildId
+        );
+        if (isKnown) {
+            safeDelete(msg);
+            await banUser(msg.member, "Autobanned: known spam image detected");
+            return;
+        }
+
+        // Accumulation path: rolling window
+        const userId = msg.author.id;
+        const state = getOrCreateState(imageChecksumState, userId);
+        pruneHistory(state);
+
+        const matching = state.history.filter(e => e.checksum === checksum);
+
+        if (matching.length >= 2) {
+            // 3rd match (2 prior + current) — store checksum + ban + delete messages
+            await yunoRef.dbCommands.addSpamChecksum(yunoRef.database, checksum, guildId);
+
+            // Delete all matching prior messages
+            for (const entry of matching) {
+                safeDelete(entry.msg);
+            }
+            safeDelete(msg);
+
+            await banUser(msg.member, "Autobanned: repeated image spam detected");
+            imageChecksumState.delete(userId);
+            return;
+        }
+
+        state.history.push({ checksum, ts: Date.now(), msg });
+    }
+}
+
 // Ban configuration
 const BAN_CONFIG = {
     deleteMessageSeconds: 86400
@@ -239,6 +317,21 @@ const spamRules = [
                 warnDM: "Please keep your messages under 4 messages long. This is your one and only warning.\nFailure to comply will result in a ban."
             });
         }
+    },
+
+    // Cross-channel rapid image spam - checksum-based detection
+    {
+        name: "image-checksum",
+        test: (content, msg) => {
+            return msg.attachments.size > 0 &&
+                [...msg.attachments.values()].some(a => a.contentType?.startsWith("image/"));
+        },
+        action: (msg) => {
+            // Non-blocking: heavy async work runs in background, message pipeline unblocked
+            processImageChecksums(msg).catch(e =>
+                console.error("[image-checksum]", e.message)
+            );
+        }
     }
 ];
 
@@ -273,4 +366,8 @@ module.exports.message = async function(content, msg) {
             return;
         }
     }
+};
+
+module.exports.discordConnected = function(Yuno) {
+    yunoRef = Yuno;
 };

--- a/src/message-processors/custom-spam-rules/447665600135823361.js
+++ b/src/message-processors/custom-spam-rules/447665600135823361.js
@@ -14,6 +14,7 @@
 */
 
 const { PermissionsBitField } = require("discord.js");
+const crypto = require("crypto");
 
 // Regex patterns
 const DISCORD_INVITE_REGEX = /(https)*(http)*:*(\/\/)*discord(.gg|app.com\/invite)\/[a-zA-Z0-9]{1,}/i;
@@ -26,6 +27,46 @@ const warnings = {
     textInNsfw: new Set(),
     imageLink: new Set()
 };
+
+// Sliding window base (ms) — both rules share this
+const BASE_WINDOW_MS = 5000;
+
+// Rule 1: per-user nsfw repeat-text tracking
+// userId -> { history: [{text: string, ts: number}], jitter: number }
+const nsfwRepeatState = new Map();
+
+// Rule 2: per-user image checksum tracking
+// userId -> { history: [{checksum: string, ts: number, msg: Message}], jitter: number }
+const imageChecksumState = new Map();
+
+// Yuno reference (set by discordConnected export)
+let yunoRef = null;
+
+/**
+ * Get or create per-user sliding window state.
+ * Jitter is randomized per burst (re-randomized when history is empty after prune).
+ */
+function getOrCreateState(stateMap, userId) {
+    let state = stateMap.get(userId);
+    if (!state) {
+        state = { history: [], jitter: 0.5 + Math.random() };
+        stateMap.set(userId, state);
+    }
+    return state;
+}
+
+/**
+ * Prune entries older than the effective window.
+ * Re-randomizes jitter if history empties (new burst will have a different window).
+ */
+function pruneHistory(state) {
+    const window = BASE_WINDOW_MS * state.jitter;
+    const cutoff = Date.now() - window;
+    state.history = state.history.filter(e => e.ts > cutoff);
+    if (state.history.length === 0) {
+        state.jitter = 0.5 + Math.random();
+    }
+}
 
 // Ban configuration
 const BAN_CONFIG = {
@@ -120,6 +161,38 @@ const spamRules = [
                 banDM: "You have been banned for repeatedly posting text in NSFW channels.",
                 warnDM: "8. Text other than links is not allowed in hentai channels. If you wish to comment on something in a hentai channel, #media or #meme-machine do so in main chat and reference the channel youre commenting on. This is to prevent unnecessary clutter so people can easily see the content posted in the channels."
             });
+        }
+    },
+
+    // NSFW channels - same text+media posted rapidly = spam bot
+    {
+        name: "nsfw-repeat-text-media",
+        test: (content, msg) => {
+            const channelName = msg.channel.name.toLowerCase();
+            if (!channelName.startsWith("nsfw_")) return false;
+            // Must have a link or attachment (pure-text is handled by nsfw-text-only above)
+            const hasLink = content.toLowerCase().includes("http");
+            const hasAttachment = msg.attachments.size > 0;
+            return hasLink || hasAttachment;
+        },
+        action: async (msg, content) => {
+            const userId = msg.author.id;
+            const text = content.trim().toLowerCase();
+
+            const state = getOrCreateState(nsfwRepeatState, userId);
+            pruneHistory(state);
+
+            const matchCount = state.history.filter(e => e.text === text).length;
+
+            if (matchCount >= 2) {
+                // 3rd repetition (2 prior + current) — ban
+                safeDelete(msg);
+                await banUser(msg.member, "Autobanned: repeated text+media spam in nsfw channels");
+                nsfwRepeatState.delete(userId);
+                return;
+            }
+
+            state.history.push({ text, ts: Date.now() });
         }
     },
 

--- a/src/message-processors/custom-spam-rules/447665600135823361.js
+++ b/src/message-processors/custom-spam-rules/447665600135823361.js
@@ -36,7 +36,7 @@ const BASE_WINDOW_MS = 5000;
 const nsfwRepeatState = new Map();
 
 // Rule 2: per-user image checksum tracking
-// userId -> { history: [{checksum: string, ts: number, msg: Message}], jitter: number }
+// userId -> { history: [{checksum: string, ts: number}], jitter: number }
 const imageChecksumState = new Map();
 
 // Yuno reference (set by discordConnected export)
@@ -128,21 +128,16 @@ async function processImageChecksums(msg) {
         const matching = state.history.filter(e => e.checksum === checksum);
 
         if (matching.length >= 2) {
-            // 3rd match (2 prior + current) — store checksum + ban + delete messages
+            // 3rd match — store checksum, delete triggering message, ban
+            // (ban with deleteMessageSeconds:86400 cleans up prior messages server-side)
             await yunoRef.dbCommands.addSpamChecksum(yunoRef.database, checksum, guildId);
-
-            // Delete all matching prior messages
-            for (const entry of matching) {
-                safeDelete(entry.msg);
-            }
             safeDelete(msg);
-
             await banUser(msg.member, "Autobanned: repeated image spam detected");
             imageChecksumState.delete(userId);
             return;
         }
 
-        state.history.push({ checksum, ts: Date.now(), msg });
+        state.history.push({ checksum, ts: Date.now() });
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds `nsfw-repeat-text-media` rule: bans users who post the same text+media in `nsfw_` channels 3 times within a ~5s jittered window
- Adds `image-checksum` rule: downloads and SHA-256 hashes image attachments; bans on 3 repeated identical images cross-channel; caches known-spam checksums in DB for instant future detection
- Both rules target hijacked/automated accounts bypassing text-based spam detection; image processing is non-blocking (fire-and-forget)

## Test Plan

- [ ] Post the same text+link in an `nsfw_` channel 3 times rapidly — user should be banned on the 3rd
- [ ] Post the same image in any channel 3 times rapidly — user should be banned on the 3rd, checksum stored in DB
- [ ] Post a previously detected spam image once — user should be immediately banned (fast path)
- [ ] Verify `deleteMessageSeconds: 86400` in BAN_CONFIG causes Discord to delete 1 day of messages on ban
- [ ] Confirm bot loads cleanly: `node -e "require('./src/message-processors/custom-spam-rules/447665600135823361.js'); console.log('OK')"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)