### PR TITLE
Increase image limit for spam detection analysis from 4MB to 10MB

### DIFF
--- a/src/message-processors/custom-spam-rules/447665600135823361.js
+++ b/src/message-processors/custom-spam-rules/447665600135823361.js
@@ -68,7 +68,7 @@ function pruneHistory(state) {
     }
 }
 
-const MAX_IMAGE_BYTES = 4 * 1024 * 1024; // 4 MB hard cap per image
+const MAX_IMAGE_BYTES = 10 * 1024 * 1024; // 10 MB (current non-Nitro Discord upload limit)
 
 /**
  * Download an image URL into a Buffer.


### PR DESCRIPTION
Increase image limit for spam detection analysis from 4MB to 10MB