### PR TITLE
Security: timing attacks, fuzz hardening, Discord injection, privilege escalation + side-channel DB scanner

### DIFF
--- a/src/message-processors/mention-responses.js
+++ b/src/message-processors/mention-responses.js
@@ -14,7 +14,9 @@ module.exports.message = async function(content, msg) {
             if (mentionResponse.image !== "null")
                 embed.setImage(mentionResponse.image);
 
-            await msg.channel.send({embeds: [embed]});
+            // allowedMentions: { parse: [] } prevents a stored response that
+            // contains <@userId> or <@&roleId> from pinging real users/roles.
+            await msg.channel.send({ embeds: [embed], allowedMentions: { parse: [] } });
             break;
         }
     }

--- a/src/modules/join-dm-msg.js
+++ b/src/modules/join-dm-msg.js
@@ -61,7 +61,7 @@ let eventDiscord = function() {
         }
 
         if (send)
-            member.send({embeds: [embed]}).catch(error => {
+            member.send({ embeds: [embed], allowedMentions: { parse: [] } }).catch(error => {
     if (error.code === 50007) {
         console.error('Failed to send message:', error);
     }

--- a/src/scripts/db-integrity-check.js
+++ b/src/scripts/db-integrity-check.js
@@ -171,32 +171,169 @@ function _tryEncrypt(plaintext, passphrase) {
 }
 
 // ---------------------------------------------------------------------------
-// Validation helpers
+// Validation helpers — base checks
 // ---------------------------------------------------------------------------
 
 const SNOWFLAKE_RE = /^\d{17,19}$/;
 
-const CHECKS = {
-    nullBytes:     (v) => typeof v === "string" && v.includes("\x00"),
-    nonNFC:        (v) => typeof v === "string" && v !== v.normalize("NFC"),
-    badSnowflake:  (v) => typeof v === "string" && v !== null && !SNOWFLAKE_RE.test(v),
-    overlength:    (v, max) => typeof v === "string" && v.length > max,
+// ---------------------------------------------------------------------------
+// Discord.js-specific / second-order injection checks
+// ---------------------------------------------------------------------------
+
+// Zero-width and invisible Unicode characters that render as nothing in Discord
+// but survive in the stored string. Used to hide content in triggers or make
+// them impossible to delete via normal UI commands.
+const ZERO_WIDTH_CHARS = [
+    "​", // ZERO WIDTH SPACE
+    "‌", // ZERO WIDTH NON-JOINER
+    "‍", // ZERO WIDTH JOINER
+    "﻿", // ZERO WIDTH NO-BREAK SPACE (BOM)
+    "⁠", // WORD JOINER
+    "­", // SOFT HYPHEN
+    " ", // LINE SEPARATOR
+    " ", // PARAGRAPH SEPARATOR
+    "‎", // LEFT-TO-RIGHT MARK
+    "‏", // RIGHT-TO-LEFT MARK
+];
+
+// Unicode directional overrides that can reverse displayed text (spoofing).
+const DIRECTIONAL_OVERRIDES = [
+    "‪", "‫", "‬", "‭", "‮", // LRE,RLE,PDF,LRO,RLO
+    "⁦", "⁧", "⁨", "⁩",            // LRI,RLI,FSI,PDI
+];
+
+// All invisible/dangerous code points combined.
+const ALL_INVISIBLE = [...ZERO_WIDTH_CHARS, ...DIRECTIONAL_OVERRIDES];
+
+// Discord mention patterns that cause real pings when sent via the API.
+// @everyone / @here in text content ping server; <@id> pings users; <@&id> pings roles.
+// These are dangerous in DB-sourced content because allowedMentions is historically
+// absent on many bot sends. Even with allowedMentions fixed, flagging these in the DB
+// is valuable for post-compromise audit.
+function hasDiscordMention(v) {
+    if (typeof v !== "string") return false;
+    if (v.includes("@everyone") || v.includes("@here")) return true;
+    // <@id>, <@!id>, <@&id> — user / legacy user / role mentions
+    for (let i = 0; i < v.length - 2; i++) {
+        if (v[i] === "<" && v[i+1] === "@") return true;
+    }
+    return false;
+}
+
+function hasInvisibleChars(v) {
+    if (typeof v !== "string") return false;
+    for (const ch of ALL_INVISIBLE) {
+        if (v.includes(ch)) return true;
+    }
+    return false;
+}
+
+// Homograph detection: check whether a string mixes characters from two or more
+// Unicode scripts (Latin + Cyrillic, Latin + Greek, etc.). Mixing scripts is a
+// strong signal of a lookalike-glyph attack. We use a simple code-point range
+// approach that catches the most common homograph scripts.
+const SCRIPT_RANGES = {
+    latin:    [[0x0041, 0x007A], [0x00C0, 0x024F], [0x1E00, 0x1EFF]],
+    cyrillic: [[0x0400, 0x04FF], [0x0500, 0x052F]],
+    greek:    [[0x0370, 0x03FF], [0x1F00, 0x1FFF]],
+    armenian: [[0x0530, 0x058F]],
+    georgian: [[0x10A0, 0x10FF]],
 };
 
-function checkValue(label, raw, decrypted, maxLen) {
+function _scriptOf(cp) {
+    for (const [name, ranges] of Object.entries(SCRIPT_RANGES)) {
+        for (const [lo, hi] of ranges) {
+            if (cp >= lo && cp <= hi) return name;
+        }
+    }
+    return null;
+}
+
+function hasMixedScripts(v) {
+    if (typeof v !== "string") return false;
+    const seen = new Set();
+    for (const ch of v) {
+        const cp = ch.codePointAt(0);
+        if (cp < 0x80) continue; // plain ASCII — skip (don't count as a "script")
+        const s = _scriptOf(cp);
+        if (s) seen.add(s);
+        if (seen.size >= 2) return true;
+    }
+    return false;
+}
+
+// URL must start with https:// or http:// to be considered safe-scheme.
+function isSafeUrl(v) {
+    if (typeof v !== "string") return true; // null/non-string → not our check
+    if (v === "null" || v === "") return true;
+    return v.startsWith("https://") || v.startsWith("http://");
+}
+
+// levelRoleMap: every key must be a valid snowflake, every value must be a snowflake.
+function validateLevelRoleMap(jsonStr) {
+    const issues = [];
+    if (!jsonStr || jsonStr === "null") return issues;
+    let parsed;
+    try {
+        parsed = JSON.parse(jsonStr);
+    } catch (e) {
+        issues.push("levelRoleMap is not valid JSON");
+        return issues;
+    }
+    if (typeof parsed !== "object" || Array.isArray(parsed) || parsed === null) {
+        issues.push("levelRoleMap is not a JSON object");
+        return issues;
+    }
+    // Prototype-poisoning keys
+    const POISON = new Set(["__proto__", "constructor", "prototype"]);
+    for (const [k, v] of Object.entries(parsed)) {
+        if (POISON.has(k)) {
+            issues.push(`levelRoleMap has poisoning key: "${k}"`);
+            continue;
+        }
+        if (!SNOWFLAKE_RE.test(String(v))) {
+            issues.push(`levelRoleMap value for level "${k}" is not a valid snowflake: "${String(v).substring(0, 30)}"`);
+        }
+    }
+    return issues;
+}
+
+const CHECKS = {
+    nullBytes:       (v) => typeof v === "string" && v.includes("\x00"),
+    nonNFC:          (v) => typeof v === "string" && v !== v.normalize("NFC"),
+    badSnowflake:    (v) => typeof v === "string" && v !== null && !SNOWFLAKE_RE.test(v),
+    overlength:      (v, max) => typeof v === "string" && v.length > max,
+    discordMention:  hasDiscordMention,
+    invisibleChars:  hasInvisibleChars,
+    mixedScripts:    hasMixedScripts,
+    unsafeUrl:       (v) => typeof v === "string" && v !== "null" && !isSafeUrl(v),
+    badEnum:         (v, allowed) => typeof v === "string" && !allowed.includes(v),
+};
+
+function checkValue(label, raw, decrypted, opts = {}) {
+    const { maxLen, checkMentions, checkInvisible, checkHomograph, checkUrl, allowedValues } = opts;
     const issues = [];
     const val = decrypted !== undefined ? decrypted : raw;
     if (val === null || val === undefined) return issues;
-    if (CHECKS.nullBytes(val))               issues.push(`null-byte in ${label}`);
-    if (CHECKS.nonNFC(val))                  issues.push(`non-NFC Unicode in ${label}`);
+    if (CHECKS.nullBytes(val))      issues.push(`null-byte in ${label}`);
+    if (CHECKS.nonNFC(val))         issues.push(`non-NFC Unicode in ${label}`);
     if (maxLen && CHECKS.overlength(val, maxLen)) issues.push(`${label} exceeds max ${maxLen} (len=${val.length})`);
+    if (checkMentions  && CHECKS.discordMention(val))  issues.push(`Discord mention injection in ${label} — pings users/roles when sent`);
+    if (checkInvisible && CHECKS.invisibleChars(val))  issues.push(`invisible/zero-width Unicode in ${label} — unremovable via Discord UI`);
+    if (checkHomograph && CHECKS.mixedScripts(val))    issues.push(`mixed-script homograph in ${label} — lookalike glyph attack`);
+    if (checkUrl       && CHECKS.unsafeUrl(val))       issues.push(`unsafe URL scheme in ${label}: "${String(val).substring(0, 80)}"`);
+    if (allowedValues  && CHECKS.badEnum(val, allowedValues))
+        issues.push(`privilege-escalation: ${label} has invalid value "${String(val).substring(0, 40)}" (allowed: ${allowedValues.join(", ")})`);
     return issues;
 }
 
 function fixValue(val) {
     if (typeof val !== "string") return { fixed: val, changed: false };
-    let fixed = val.replace(/\x00/g, ""); // strip null bytes
-    fixed = fixed.normalize("NFC");       // NFC normalize
+    let fixed = val.replace(/\x00/g, "");    // strip null bytes
+    for (const ch of ALL_INVISIBLE) {
+        fixed = fixed.split(ch).join("");     // strip invisible/directional chars
+    }
+    fixed = fixed.normalize("NFC");          // NFC normalize
     return { fixed, changed: fixed !== val };
 }
 
@@ -205,7 +342,10 @@ function fixValue(val) {
 // max lengths, and whether they're snowflakes.
 // ---------------------------------------------------------------------------
 
-// Each entry: { table, pk, columns: [{ name, encrypted?, maxLen?, snowflake?, fixable? }] }
+// Each entry: { table, pk, columns: [{ name, encrypted?, maxLen?, snowflake?,
+//   fixable?, checkMentions?, checkInvisible?, checkHomograph?, checkUrl?,
+//   customCheck? }] }
+// customCheck: fn(row) => string[] of issues (for cross-column or JSON checks)
 const SCHEMA = [
     {
         table: "mentionResponses",
@@ -213,9 +353,15 @@ const SCHEMA = [
         updatePk: true,
         columns: [
             { name: "gid",      snowflake: true },
-            { name: "trigger",  encrypted: true, maxLen: 200,  fixable: true },
-            { name: "response", encrypted: true, maxLen: 2000, fixable: true },
-            { name: "image",    encrypted: true, fixable: true },
+            // trigger: invisible chars make it unremovable in Discord UI;
+            //          mixed scripts enable lookalike-trigger attacks.
+            { name: "trigger",  encrypted: true, maxLen: 200,  fixable: true,
+              checkInvisible: true, checkHomograph: true },
+            // response: mention injection pings users/roles when sent.
+            { name: "response", encrypted: true, maxLen: 2000, fixable: true,
+              checkMentions: true, checkInvisible: true },
+            // image: must be a real HTTP(S) URL, not an arbitrary scheme.
+            { name: "image",    encrypted: true, fixable: false, checkUrl: true },
         ],
     },
     {
@@ -225,9 +371,13 @@ const SCHEMA = [
         columns: [
             { name: "id",               snowflake: true },
             { name: "prefix",           maxLen: 10, fixable: false },
-            { name: "onJoinDMMsg",      encrypted: true, maxLen: 2000, fixable: true },
-            { name: "onJoinDMMsgTitle", encrypted: true, maxLen: 255, fixable: true },
+            { name: "onJoinDMMsg",      encrypted: true, maxLen: 2000, fixable: true,
+              checkMentions: true, checkInvisible: true },
+            { name: "onJoinDMMsgTitle", encrypted: true, maxLen: 255, fixable: true,
+              checkInvisible: true },
         ],
+        // Extra: validate levelRoleMap JSON structure and snowflake keys.
+        extraCheck: (row) => validateLevelRoleMap(row.levelRoleMap),
     },
     {
         table: "botBans",
@@ -235,10 +385,27 @@ const SCHEMA = [
         updatePk: true,
         columns: [
             { name: "id",       snowflake: true },
-            { name: "type",     fixable: false }, // enum: user/guild
-            { name: "reason",   encrypted: true, maxLen: 500, fixable: true },
-            { name: "bannedBy", snowflake: false, fixable: false },
+            // type must be 'user' or 'guild' — any other value bypasses
+            // the type-check logic in isBotBanned and could skip enforcement.
+            { name: "type",     fixable: false, allowedValues: ["user", "guild"] },
+            { name: "reason",   encrypted: true, maxLen: 500, fixable: true,
+              checkInvisible: true },
+            // bannedBy: should be a snowflake or "system" (automated bans).
+            // A non-snowflake non-system value indicates a tampered audit trail.
+            { name: "bannedBy", fixable: false },
         ],
+        // Self-ban: id === bannedBy is suspicious (locks out a user who can re-ban themselves).
+        // Also flags system-attributed bans with non-automated reasons (manual tampering).
+        extraCheck: (row) => {
+            const issues = [];
+            if (row.id && row.bannedBy && row.id === row.bannedBy) {
+                issues.push(`privilege-escalation: bot-ban self-reference — id and bannedBy are the same (${row.id})`);
+            }
+            if (row.bannedBy && row.bannedBy !== "system" && !SNOWFLAKE_RE.test(row.bannedBy)) {
+                issues.push(`privilege-escalation: bannedBy is neither a snowflake nor "system": "${String(row.bannedBy).substring(0, 40)}"`);
+            }
+            return issues;
+        },
     },
     {
         table: "modActions",
@@ -248,8 +415,20 @@ const SCHEMA = [
             { name: "gid",         snowflake: true },
             { name: "moderatorId", snowflake: true },
             { name: "targetId",    snowflake: true },
-            { name: "reason",      encrypted: true, maxLen: 500, fixable: true },
+            // action: only these values are written by the bot. Unexpected values
+            // indicate either a bug or a tampered audit log entry.
+            { name: "action",  fixable: false,
+              allowedValues: ["ban", "kick", "unban", "timeout", "warn", "mute"] },
+            { name: "reason",  encrypted: true, maxLen: 500, fixable: true,
+              checkInvisible: true },
         ],
+        // Flag entries where moderator banned themselves (audit trail anomaly).
+        extraCheck: (row) => {
+            if (row.moderatorId && row.targetId && row.moderatorId === row.targetId) {
+                return [`privilege-escalation: modAction self-target — moderator and target are the same ID (${row.moderatorId})`];
+            }
+            return [];
+        },
     },
     {
         table: "dmInbox",
@@ -257,9 +436,10 @@ const SCHEMA = [
         updatePk: true,
         columns: [
             { name: "usrId",       snowflake: true },
-            { name: "userTag",     maxLen: 200, fixable: true },
-            { name: "content",     encrypted: true, maxLen: 4000, fixable: true },
-            { name: "attachments", encrypted: true, fixable: true },
+            { name: "userTag",     maxLen: 200, fixable: true, checkInvisible: true },
+            { name: "content",     encrypted: true, maxLen: 4000, fixable: true,
+              checkInvisible: true },
+            { name: "attachments", encrypted: true, fixable: false },
         ],
     },
     {
@@ -268,18 +448,151 @@ const SCHEMA = [
         columns: [
             { name: "gid",    snowflake: true },
             { name: "banner", snowflake: true },
-            { name: "image",  encrypted: true, fixable: true },
+            // Image URLs loaded into Discord embeds — must be HTTP(S).
+            { name: "image",  encrypted: true, fixable: false, checkUrl: true },
         ],
     },
     {
         table: "botPresence",
         pk: "id",
         columns: [
-            { name: "text",      maxLen: 500, fixable: true },
-            { name: "streamUrl", maxLen: 500, fixable: true },
+            { name: "text",      maxLen: 500, fixable: true, checkInvisible: true },
+            { name: "streamUrl", maxLen: 500, fixable: false, checkUrl: true },
         ],
     },
+    {
+        table: "altDetectorConfig",
+        pk: "gid",
+        columns: [
+            { name: "gid",              snowflake: true },
+            { name: "logChannelId",     snowflake: false }, // may be null
+            { name: "quarantineRoleId", snowflake: false }, // may be null
+            // Action fields: all must be one of the valid alt-detector actions.
+            // A tampered 'ban' on actionNewbie would auto-ban all new accounts.
+            { name: "actionNewbie",          fixable: false,
+              allowedValues: ["none", "log", "kick", "ban", "role"] },
+            { name: "actionSuspicious",      fixable: false,
+              allowedValues: ["none", "log", "kick", "ban", "role"] },
+            { name: "actionHighlySuspicious",fixable: false,
+              allowedValues: ["none", "log", "kick", "ban", "role"] },
+            { name: "actionMegaSuspicious",  fixable: false,
+              allowedValues: ["none", "log", "kick", "ban", "role"] },
+        ],
+    },
+    {
+        table: "guilds",
+        pk: "id",
+        columns: [
+            // Prefix: empty-string prefix causes the bot to respond to every
+            // message. A very long prefix is also suspicious (denial-of-service
+            // via preventing any commands from matching).
+            { name: "prefix", maxLen: 10, fixable: false },
+        ],
+        extraCheck: (row) => {
+            const issues = [];
+            if (typeof row.prefix === "string" && row.prefix.trim() === "") {
+                issues.push("privilege-escalation: guild prefix is empty — bot would respond to every message");
+            }
+            return issues;
+        },
+    },
 ];
+
+// ---------------------------------------------------------------------------
+// Side-channel / cross-table statistical checks
+//
+// These look at patterns across rows rather than individual field values.
+// A side-channel attack uses observable metadata (timing, counts, deltas)
+// to infer information that should not be directly visible.
+// ---------------------------------------------------------------------------
+
+function runSideChannelChecks(issues) {
+    // 1. Mass-ban burst: more than N bot-bans created within a short window
+    //    suggests either an exploit that auto-banned a crowd, or an attacker
+    //    with DB access performing a mass-ban to lock legitimate users out.
+    try {
+        const BURST_WINDOW_MS  = 60_000; // 1 minute
+        const BURST_THRESHOLD  = 10;     // bans per window considered suspicious
+        const bans = queryAll("SELECT bannedAt FROM botBans ORDER BY bannedAt ASC");
+        for (let i = 0; i <= bans.length - BURST_THRESHOLD; i++) {
+            const window = bans[i + BURST_THRESHOLD - 1].bannedAt - bans[i].bannedAt;
+            if (window <= BURST_WINDOW_MS) {
+                issues.push(`[side-channel] mass-ban burst: ${BURST_THRESHOLD}+ bot-bans within ${BURST_WINDOW_MS / 1000}s window — possible DM-exploit abuse or DB-level mass-ban`);
+                break;
+            }
+        }
+    } catch { /* table absent on fresh DB */ }
+
+    // 2. spamChecksums insertion by non-organic source: checksums that were
+    //    inserted more than 1 day before the bot last started (based on oldest
+    //    vcSession or experience entry) may have been pre-seeded to cause
+    //    false-positive spam bans on specific users.
+    //    We check for checksums with unusually old or future timestamps.
+    try {
+        const now = Date.now();
+        const FAR_FUTURE = now + 24 * 60 * 60 * 1000; // 1 day into future
+        const checksums = queryAll("SELECT checksum, guildId, detectedAt FROM spamChecksums");
+        for (const row of checksums) {
+            if (row.detectedAt > FAR_FUTURE) {
+                issues.push(`[side-channel] spamChecksums[${row.guildId}/${row.checksum.substring(0,16)}]: future timestamp (${row.detectedAt}) — may be pre-seeded to trigger spam-ban`);
+            }
+        }
+    } catch { /* table absent */ }
+
+    // 3. vcSessions with joinedAt in the far future: would keep a fake session
+    //    "active" indefinitely, skewing XP grants and potentially triggering
+    //    rate-limit or quota logic abnormally.
+    try {
+        const now = Date.now();
+        const FAR_FUTURE = now + 24 * 60 * 60 * 1000;
+        const sessions = queryAll("SELECT gid, usrId, joinedAt FROM vcSessions");
+        for (const row of sessions) {
+            if (row.joinedAt > FAR_FUTURE) {
+                issues.push(`[side-channel] vcSessions[${row.gid}+${row.usrId}]: joinedAt is in the future (${row.joinedAt}) — may cause unbounded XP accumulation`);
+            }
+        }
+    } catch { /* table absent */ }
+
+    // 4. DM inbox timing correlation: if many DM inbox entries share the exact
+    //    same timestamp, they were either bulk-inserted (programmatic) or the
+    //    timestamp field has been zeroed to erase the audit trail.
+    try {
+        const CLONE_THRESHOLD = 5;
+        const dmRows = queryAll("SELECT timestamp FROM dmInbox ORDER BY timestamp");
+        const tsCounts = new Map();
+        for (const row of dmRows) {
+            tsCounts.set(row.timestamp, (tsCounts.get(row.timestamp) || 0) + 1);
+        }
+        for (const [ts, count] of tsCounts) {
+            if (count >= CLONE_THRESHOLD) {
+                issues.push(`[side-channel] dmInbox: ${count} entries share identical timestamp ${ts} — possible bulk-insert or timestamp zeroing (audit trail erasure)`);
+            }
+        }
+    } catch { /* table absent */ }
+
+    // 5. Experience table: single user with exp values far above all others
+    //    in the same guild — indicates direct DB manipulation to elevate XP
+    //    (which drives role assignments via levelRoleMap).
+    try {
+        const expRows = queryAll("SELECT guildID, userID, exp FROM experiences");
+        // Group by guild
+        const byGuild = new Map();
+        for (const row of expRows) {
+            if (!byGuild.has(row.guildID)) byGuild.set(row.guildID, []);
+            byGuild.get(row.guildID).push(row.exp);
+        }
+        for (const [gid, exps] of byGuild) {
+            if (exps.length < 2) continue;
+            const sorted = [...exps].sort((a, b) => b - a);
+            const max = sorted[0];
+            const secondMax = sorted[1];
+            // Flag if top user has >10× the second-highest (suggests tampering)
+            if (secondMax > 0 && max > secondMax * 10) {
+                issues.push(`[side-channel] experiences[guild:${gid}]: top XP (${max}) is >10× second-highest (${secondMax}) — possible XP tampering to force role escalation`);
+            }
+        }
+    } catch { /* table absent */ }
+}
 
 // ---------------------------------------------------------------------------
 // Main scan
@@ -301,7 +614,7 @@ console.log(`  Fix mode:   ${FIX_MODE ? "YES — changes will be written" : "no 
 console.log(`  Verbose:    ${VERBOSE}`);
 console.log();
 
-for (const { table, pk, columns } of SCHEMA) {
+for (const { table, pk, columns, extraCheck } of SCHEMA) {
     let rows;
     try {
         rows = queryAll(`SELECT * FROM ${table}`);
@@ -338,16 +651,23 @@ for (const { table, pk, columns } of SCHEMA) {
             }
 
             // --- content checks (on decrypted value) ---
-            const issues = checkValue(col.name, raw, col.encrypted && passphrase ? decrypted : undefined, col.maxLen);
+            const val = col.encrypted && passphrase ? decrypted : raw;
+            const issues = checkValue(col.name, raw, col.encrypted && passphrase ? decrypted : undefined, {
+                maxLen:        col.maxLen,
+                checkMentions: col.checkMentions,
+                checkInvisible:col.checkInvisible,
+                checkHomograph:col.checkHomograph,
+                checkUrl:      col.checkUrl,
+                allowedValues: col.allowedValues,
+            });
             if (issues.length > 0) {
                 for (const iss of issues) {
                     rowIssues.push(`  ⚠  ${rowLabel}: ${iss}`);
                 }
 
-                if (col.fixable && passphrase !== null || (col.fixable && !col.encrypted)) {
-                    const { fixed, changed } = fixValue(decrypted);
+                if (col.fixable && (passphrase !== null || !col.encrypted)) {
+                    const { fixed, changed } = fixValue(typeof val === "string" ? val : decrypted);
                     if (changed) {
-                        // Re-encrypt if the field was encrypted
                         rowFixes[col.name] = col.encrypted && passphrase
                             ? _tryEncrypt(fixed, passphrase)
                             : fixed;
@@ -355,6 +675,15 @@ for (const { table, pk, columns } of SCHEMA) {
                 } else if (!col.fixable) {
                     canFixAll = false;
                 }
+            }
+        }
+
+        // --- per-table extra checks (e.g. JSON structure) ---
+        if (extraCheck) {
+            const extras = extraCheck(row);
+            for (const iss of extras) {
+                rowIssues.push(`  ⚠  ${rowLabel}: ${iss}`);
+                canFixAll = false; // JSON structural issues require manual fix
             }
         }
 
@@ -389,6 +718,23 @@ for (const { table, pk, columns } of SCHEMA) {
             console.log(`  OK ${rowLabel}`);
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Side-channel / statistical checks (cross-table)
+// ---------------------------------------------------------------------------
+
+const sideChannelIssues = [];
+runSideChannelChecks(sideChannelIssues);
+if (sideChannelIssues.length > 0) {
+    console.log(`\n[Cross-table side-channel analysis] — ${sideChannelIssues.length} finding(s):`);
+    for (const iss of sideChannelIssues) {
+        console.log(`  ⚠  ${iss}`);
+        totalIssues++;
+    }
+    flagged.push({ table: "(cross-table)", pk: "N/A", issues: sideChannelIssues });
+} else if (VERBOSE) {
+    console.log("\n[Cross-table side-channel analysis] — no findings.");
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR covers four rounds of hardening added since PR #125 was merged:

### Timing-attack mitigations
- `getMentionResponseFromTrigger`: full-scan loop replaces `Array.find()` — short-circuit would leak match position via PBKDF2 decryption count (each call = 100k iterations, timing is network-observable)
- `crypto.timingSafeEqual` via `_timingSafeStringEqual` for all encrypted-trigger comparisons
- `_jitterDelay()` (10–40 ms random) before all per-DM logic — masks LRU cache hit vs DB miss timing from a banned user probing their own status

### Fuzz hardening
- `_assertBoundedString`: null-byte rejection — SQLite (C) truncates at `\x00`, enabling stored `"abc\x00DROP TABLE"` → `"abc"`
- NFC normalization on trigger insert and lookup (lookalike Unicode glyphs can't bypass trigger matching)
- `eval.js` removed from tracking; gitignore entry with dev-only warning

### Discord.js second-order injection (SQL → Discord)
- `allowedMentions: { parse: [] }` added to all sends using DB-sourced embed content (mention-responses, join-DM) — previously `<@userId>` in a stored response would ping real users
- DB integrity scanner detects: mention injection, zero-width/invisible Unicode in triggers (unremovable in Discord UI), RTL directional overrides, mixed-script homographs, unsafe URL schemes, levelRoleMap JSON poisoning keys

### Privilege escalation checks (in DB scanner)
- `botBans.type` enum: only `user`/`guild` allowed — other values bypass `isBotBanned` enforcement
- Self-ban detection (`id === bannedBy`)
- `bannedBy` must be a snowflake or literal `"system"`
- `modActions.action` enum validation; self-target detection
- `altDetectorConfig` action fields validated — tampered `ban` on `actionNewbie` would auto-ban all new accounts
- Empty guild prefix detection (bot would respond to every message)

### Side-channel / statistical DB checks
- Mass-ban burst: 10+ bans within 60 s → exploit abuse or DB-level attack
- `spamChecksums` future timestamps → pre-seeded false-positive spam bans
- `vcSessions` future `joinedAt` → unbounded XP accumulation
- `dmInbox` timestamp clustering → bulk insert or audit trail erasure
- XP outlier: top user >10× second-highest → DB-manipulation for role escalation via `levelRoleMap`

### Post-startup DB integrity scanner
- `src/scripts/db-integrity-check.js` — all checks above run at bot startup via `setImmediate + execFile` (non-blocking)
- `npm run check-db` / `npm run check-db:fix` for manual invocation
- `--passphrase` flag decrypts encrypted fields in-place for content analysis
- `--fix` re-encrypts sanitized values; structural/escalation issues flagged for manual review, never auto-deleted

## Test plan
- [ ] `npm run check-db` on clean DB → exit 0
- [ ] Insert a row with `\x00` directly in SQLite → exit 1, row flagged; `--fix` removes it
- [ ] Insert a `mentionResponse` with `<@everyone>` in response → flagged as mention injection
- [ ] Set `botBans.type = 'admin'` directly → flagged as privilege escalation
- [ ] Insert 11 `botBans` within 1 minute window → side-channel mass-ban burst flagged
- [ ] Send DM with a trigger that has an invisible char → flagged as unremovable
- [ ] Bot startup → `[DB-INTEGRITY]` line appears in console

🤖 Generated with [Claude Code](https://claude.com/claude-code)