### PR TITLE
Security: source-code vulnerability audit (injection, encoding, info-disclosure)

### DIFF
--- a/src/Yuno.js
+++ b/src/Yuno.js
@@ -100,7 +100,13 @@ class Yuno extends EventEmitter {
                 GatewayIntentBits.GuildBans,
                 GatewayIntentBits.GuildVoiceStates,
                 GatewayIntentBits.GuildPresences
-            ]
+            ],
+            // Global allowedMentions default: allow only explicit user pings
+            // (which the bot inserts as snowflakes it controls), never role
+            // mentions or @everyone/@here. Any user-controlled content echoed
+            // in a message cannot cause unintended mass pings.
+            // Commands that legitimately need role mentions override per-send.
+            allowedMentions: { parse: ["users"] },
         });
         this.dC = this.discordClient;
 
@@ -347,6 +353,10 @@ ${YUNO_PINK}           "I'll protect this server forever... just for you~"${RESE
             token: {
                 test: (arg) => arg.startsWith("--token"),
                 handle: (arg) => {
+                    // WARNING: passing the token as a CLI argument exposes it
+                    // in `ps aux` output and shell history. Prefer storing it in
+                    // config.json or a DISCORD_TOKEN environment variable instead.
+                    prompt.warning("[SECURITY] --token passed via CLI — visible in process list (ps aux). Prefer config.json.");
                     CUSTOM_TOKEN = arg.startsWith("--token=")
                         ? arg.split("=")[1]
                         : (prompt.warning("Not any new token defined. You have to define token like --token=yourtoken"), null);

--- a/src/commands/auto-clean.js
+++ b/src/commands/auto-clean.js
@@ -95,9 +95,12 @@ const subcommandHandlers = {
         if (clean === null)
             return msg.channel.send(":negative_squared_cross_mark: This channel doesn't have any auto-clean set up.");
 
+        const delayMinutes = parseInt(args[1], 10);
+        if (isNaN(delayMinutes) || delayMinutes <= 0)
+            return msg.channel.send(":negative_squared_cross_mark: Delay must be a positive number of minutes.");
         const { timeFEachClean, timeBeforeClean, remainingTime } = clean;
-        await dbCommands.setClean(database, ch.guild.id, ch.name, timeFEachClean, timeBeforeClean, remainingTime + parseInt(args[1]));
-        return msg.channel.send(`:white_check_mark: Delayed the clean from ${args[1]} minutes!`);
+        await dbCommands.setClean(database, ch.guild.id, ch.name, timeFEachClean, timeBeforeClean, remainingTime + delayMinutes);
+        return msg.channel.send(`:white_check_mark: Delayed the clean by ${delayMinutes} minutes!`);
     },
 
     async addOrEdit(yuno, ch, args, msg) {

--- a/src/commands/clean.js
+++ b/src/commands/clean.js
@@ -53,7 +53,7 @@ module.exports.run = async function(yuno, author, args, msg) {
                     .setAuthor({name: "Yuno is done cleaning.", iconURL: yuno.UTIL.getAvatarURL(yuno.dC.user)})
                     .setColor("#ff51ff")]});
                 } catch(e) {
-                    msg.author.send("Cleaning failed: ```" + e.message + "```" + "```" + e.stack + "```");
+                    msg.author.send("Cleaning failed: ```" + String(e.message).substring(0, 200) + "```");
                 }
             }
             coll.stop();

--- a/src/commands/exportbans.js
+++ b/src/commands/exportbans.js
@@ -48,7 +48,7 @@ module.exports.run = async function(yuno, author, args, msg) {
             await statusMsg.edit(`Error while saving bans :( :${err.code}`);
         }
     } catch(e) {
-        msg.channel.send("Error while fetching bans: " + e.message);
+        msg.channel.send("Error while fetching bans: " + String(e.message).substring(0, 150));
         console.error("Export bans error:", e);
     }
 }

--- a/src/commands/hentai.js
+++ b/src/commands/hentai.js
@@ -39,8 +39,18 @@ module.exports.run = async function(yuno, author, args, msg) {
         args.shift();
     }
 
-    let url = 'https://rule34.xxx/index.php?page=dapi&s=post&q=index&json=1&limit=100';
-    url += args[0] ? `&tags=${args[0]}` : `&pid=${Math.ceil(Math.random() * 2000)}`;
+    const base = new URL('https://rule34.xxx/index.php');
+    base.searchParams.set('page', 'dapi');
+    base.searchParams.set('s', 'post');
+    base.searchParams.set('q', 'index');
+    base.searchParams.set('json', '1');
+    base.searchParams.set('limit', '100');
+    if (args[0]) {
+        base.searchParams.set('tags', args[0]);
+    } else {
+        base.searchParams.set('pid', String(Math.ceil(Math.random() * 2000)));
+    }
+    const url = base.toString();
 
     let res;
     try {

--- a/src/commands/importbans.js
+++ b/src/commands/importbans.js
@@ -127,7 +127,7 @@ module.exports.run = async function(yuno, author, args, msg) {
 
     } catch (e) {
         console.log(`[BanMSystem] Bans weren't saved as JSON or bulk ban failed. Error: ${e.message}`);
-        msg.channel.send(`Error during ban import: ${e.message}`);
+        msg.channel.send(`Error during ban import (check server logs for details).`);
     }
 };
 

--- a/src/commands/set-presence.js
+++ b/src/commands/set-presence.js
@@ -79,7 +79,7 @@ module.exports.run = async function(yuno, author, args, msg) {
             await yuno.dbCommands.clearPresence(yuno.database);
             return msg.channel.send(":white_check_mark: Presence cleared~");
         } catch (e) {
-            return msg.channel.send(`:negative_squared_cross_mark: Failed to clear presence: ${e.message}`);
+            return msg.channel.send(`:negative_squared_cross_mark: Failed to clear presence: ${String(e.message).substring(0, 150)}`);
         }
     }
 
@@ -107,7 +107,7 @@ module.exports.run = async function(yuno, author, args, msg) {
             };
             return msg.channel.send(`${statusEmoji[status]} Status set to **${status}**~`);
         } catch (e) {
-            return msg.channel.send(`:negative_squared_cross_mark: Failed to set status: ${e.message}`);
+            return msg.channel.send(`:negative_squared_cross_mark: Failed to set status: ${String(e.message).substring(0, 150)}`);
         }
     }
 
@@ -167,7 +167,7 @@ Example: \`set-presence streaming My Stream https://twitch.tv/example\``);
         const typeDisplay = subcommand.charAt(0).toUpperCase() + subcommand.slice(1);
         return msg.channel.send(`:white_check_mark: Now **${typeDisplay}** ${activityText}${streamUrl ? ` (${streamUrl})` : ""}~`);
     } catch (e) {
-        return msg.channel.send(`:negative_squared_cross_mark: Failed to set presence: ${e.message}`);
+        return msg.channel.send(`:negative_squared_cross_mark: Failed to set presence: ${String(e.message).substring(0, 150)}`);
     }
 }
 

--- a/src/commands/timeout.js
+++ b/src/commands/timeout.js
@@ -91,7 +91,7 @@ module.exports.run = async function(yuno, author, args, msg) {
 
     } catch (e) {
         console.error("Timeout error:", e);
-        return msg.channel.send(`:x: Error timing out user: ${e.message}`);
+        return msg.channel.send(`:x: Error timing out user: ${String(e.message).substring(0, 150)}`);
     }
 }
 


### PR DESCRIPTION
## Summary

Full audit against the OWASP/JS security checklist provided. Findings and fixes:

### 1. Dependency audit
`npm audit` — **0 vulnerabilities** across all packages.

### 2. Unintended script execution / mention injection (Discord XSS analog)
- **Yuno.js** — added `allowedMentions: { parse: ['users'] }` at the Discord `Client` constructor level. This is a single global fix: every `channel.send()` / `user.send()` / `channel.reply()` across the entire bot now defaults to no role pings and no `@everyone`/`@here`, regardless of what the message content contains. A `<@&roleId>` injected via args, a username, or DB content can no longer cause a mass ping. Commands that intentionally need to mention roles override per-send.

### 3. Input encoding (point 3 — escaping)
- **hentai.js** — `args[0]` was concatenated directly into the rule34 API URL (`&tags=<user_input>`), allowing query-parameter injection (e.g. `&limit=1000` override, extra params). Replaced with `new URL() / URLSearchParams` which encodes all values via `encodeURIComponent` automatically.

### 4. Input validation (point 5)
- **auto-clean.js** — `args[1]` (delay minutes) was used in `parseInt()` but the raw string was echoed in the confirmation and stored as-is in the DB. If non-numeric, `NaN` would be written to the DB and the raw arg string would be reflected in the channel message. Added explicit `isNaN` guard; echo now uses the parsed integer.

### 5. Information disclosure — error messages in public channels (point 6 — server-side validation)
Error messages from Discord.js and SQLite can contain internal file paths, query text, and other sensitive detail. All public-channel `e.message` echoes are now truncated or genericized:
- **clean.js** — `e.stack` removed from DM (exposed full `/home/blubskye/...` paths); `e.message` truncated to 200 chars
- **set-presence.js** — 3× truncated to 150 chars
- **timeout.js** — truncated to 150 chars
- **exportbans.js** — truncated to 150 chars
- **importbans.js** — replaced with `"check server logs"` (ban import errors can include file paths and bulk-ban detail)

### 7. Session / token protection (point 7)
- **Yuno.js** — added warning when `--token=` CLI flag is used: the token is visible in `ps aux` output and shell history on multi-user systems. Directs users to store it in config.json instead.

### Not applicable to this codebase
- XSS via DOM (no browser context — server-side Discord bot)
- CSRF tokens (Discord API authenticates via bot token on the server, not browser cookies)
- Client-side vs. server-side validation split (all validation runs in the bot process)

## Test plan
- [ ] Send `!delay #channel <@&roleId>` — confirm no role ping, NaN no longer stored
- [ ] Send `!hentai xxx&limit=9999` — confirm `limit` stays `100` in the actual API request
- [ ] Start bot with `--token=xxx` — confirm warning appears in console
- [ ] Trigger a clean error — confirm no stack trace in DM, message truncated
- [ ] Start bot — confirm no role pings from any existing command output

🤖 Generated with [Claude Code](https://claude.com/claude-code)