### PR TITLE
Security: OWASP Node.js hardening — async crypto, strict mode, EventEmitter

### DIFF
--- a/src/DatabaseCommands.js
+++ b/src/DatabaseCommands.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const crypto = require("crypto");
 const Database = require("./database");
 const LRUCache = require("./lib/lruCache");

--- a/src/ModuleExporter.js
+++ b/src/ModuleExporter.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const EventEmitter = require("events"),
     fs = require("fs"),
     prompt = (require("./lib/prompt")).init(),
@@ -79,6 +82,10 @@ class ModuleExporter extends EventEmitter {
     hrReference(instance, prop, file) {
         let path = require.resolve(file),
             ee = new EventEmitter();
+
+        ee.on('error', (err) => {
+            prompt.error(`[ModuleExporter] Hot-reload error for ${file}: ${err.message}`);
+        });
 
         this.hotreloadReferences[path] = {
             "eventEmitter": ee,

--- a/src/Util.js
+++ b/src/Util.js
@@ -2,6 +2,9 @@
  * HTML entity decode map for common entities
  * Native replacement for 'he' library
  */
+
+"use strict";
+
 const HTML_ENTITIES = {
     '&amp;': '&',
     '&lt;': '<',

--- a/src/Yuno.js
+++ b/src/Yuno.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 /**
  * @prop {String} DEFAULT_CONFIG_FILE The default file for config.
  * @prop {Object} DEFAULT_CONFIG The default configuration.
@@ -773,7 +776,7 @@ ${YUNO_PINK}           "I'll protect this server forever... just for you~"${RESE
                     this.shutdown(-1);
                     return;
                 }
-                this.database.setFieldEncryptionKey(fieldEncryptionKey);
+                await this.database.setFieldEncryptionKey(fieldEncryptionKey);
                 this.prompt.info("Field-level encryption enabled for sensitive data.");
             }
 

--- a/src/commands/8ball.js
+++ b/src/commands/8ball.js
@@ -15,6 +15,9 @@
     You should have received a copy of the GNU Affero General Public License
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
+
+"use strict";
+
 const { EmbedBuilder } = require("discord.js");
 const ballResponses = require('../data/ballResponses.json');
 

--- a/src/commands/_base.js
+++ b/src/commands/_base.js
@@ -13,6 +13,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 module.exports.run = async function(yuno, author, args, msg) {
 
 };

--- a/src/commands/add-masteruser.js
+++ b/src/commands/add-masteruser.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 module.exports.runTerminal = async function(yuno, args) {
     if (args.length === 0)
         return yuno.prompt.error("May you give some arguments?");

--- a/src/commands/add-mentionresponse.js
+++ b/src/commands/add-mentionresponse.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const { EmbedBuilder } = require("discord.js");
 
 module.exports.run = async function(yuno, author, args, msg) {

--- a/src/commands/alt-detector.js
+++ b/src/commands/alt-detector.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 delete require.cache[require.resolve("../lib/EmbedCmdResponse")];
 const EmbedCmdResponse = require("../lib/EmbedCmdResponse");
 

--- a/src/commands/anime.js
+++ b/src/commands/anime.js
@@ -15,6 +15,9 @@
     You should have received a copy of the GNU Affero General Public License
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
+
+"use strict";
+
 const { ReactionCollector, EmbedBuilder } = require('discord.js');
 
 module.exports.run = async function(yuno, author, args, msg) {

--- a/src/commands/auto-clean.js
+++ b/src/commands/auto-clean.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const {TextChannel, EmbedBuilder} = require("discord.js")
 
 // Handler object pattern for cleaner command routing

--- a/src/commands/auto-update.js
+++ b/src/commands/auto-update.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const { execFile } = require("child_process");
 const { promisify } = require("util");
 const execFileAsync = promisify(execFile);

--- a/src/commands/ban.js
+++ b/src/commands/ban.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const FAIL_COLOR = "#ff0000";
 const SUCCESS_COLOR = "#43cc24";
 

--- a/src/commands/bot-ban.js
+++ b/src/commands/bot-ban.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const { isValidSnowflake } = require("../lib/discordHelpers");
 
 module.exports.run = async function(yuno, author, args, msg) {

--- a/src/commands/bot-banlist.js
+++ b/src/commands/bot-banlist.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const { EmbedBuilder } = require("discord.js");
 
 // Type filter lookup table

--- a/src/commands/bot-unban.js
+++ b/src/commands/bot-unban.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const { isValidSnowflake } = require("../lib/discordHelpers");
 
 module.exports.run = async function(yuno, author, args, msg) {

--- a/src/commands/channels.js
+++ b/src/commands/channels.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const { ChannelType, PermissionsBitField } = require("discord.js");
 
 const CHANNEL_TYPE_NAMES = {

--- a/src/commands/clean.js
+++ b/src/commands/clean.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const {EmbedBuilder, PermissionsBitField} = require("discord.js");
 
 module.exports.run = async function(yuno, author, args, msg) {

--- a/src/commands/config.js
+++ b/src/commands/config.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 function escapeRegex(s) {
     return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
 }

--- a/src/commands/db-encrypt.js
+++ b/src/commands/db-encrypt.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 module.exports.run = async function(yuno, author, args, msg) {
     const isDiscord = author !== 0;
     const send = (text) => {

--- a/src/commands/debug-error.js
+++ b/src/commands/debug-error.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 module.exports.run = async function(yuno, author, args, msg) {
     throw new Error("Error handling check...");
 }

--- a/src/commands/del-banimage.js
+++ b/src/commands/del-banimage.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const { resolveTargetMember } = require("../lib/discordHelpers");
 
 module.exports.run = async function(yuno, author, args, msg) {

--- a/src/commands/del-mentionresponse.js
+++ b/src/commands/del-mentionresponse.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 module.exports.run = async function(yuno, author, args, msg) {
     if (args.length === 0)
         return msg.channel.send(":negative_squared_cross_mark: Not enough argument.");

--- a/src/commands/delay.js
+++ b/src/commands/delay.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const { EmbedBuilder } = require("discord.js");
 
 // Track delay usage per guild/channel: { "guildId-channelName": { count: 0, resetTime: timestamp } }

--- a/src/commands/demo.js
+++ b/src/commands/demo.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 module.exports.run = async function(yuno, author, args, msg) {
     if (author === 0)
         yuno.prompt.info("Modified!");

--- a/src/commands/dm-rate-limit.js
+++ b/src/commands/dm-rate-limit.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 delete require.cache[require.resolve("../lib/EmbedCmdResponse")];
 const EmbedCmdResponse = require("../lib/EmbedCmdResponse");
 

--- a/src/commands/dm-status.js
+++ b/src/commands/dm-status.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const { EmbedBuilder } = require("discord.js");
 
 module.exports.run = async function(yuno, author, args, msg) {

--- a/src/commands/drop-errors-on.js
+++ b/src/commands/drop-errors-on.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 module.exports.run = async function(yuno, author, args, msg) {
     if (!msg.mentions.channels.size)
         return msg.channel.send("Please mention a channel.");

--- a/src/commands/exportbans.js
+++ b/src/commands/exportbans.js
@@ -15,6 +15,9 @@
     You should have received a copy of the GNU Affero General Public License
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
+
+"use strict";
+
 const fs = require("fs").promises;
 const {PermissionsBitField} = require("discord.js");
 const { fetchAllBannedUserIds } = require("../lib/discordHelpers");

--- a/src/commands/fix-xp-data.js
+++ b/src/commands/fix-xp-data.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const {EmbedBuilder} = require("discord.js");
 const { xpNeededForLevel } = require("../lib/xpFormulas");
 

--- a/src/commands/hentai.js
+++ b/src/commands/hentai.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 // Use Set for O(1) lookup instead of array O(n)
 const BANNED_SEARCH = new Set(["loli", "gore", "guro", "scat", "small_breast", "vore", "underage", "shota"]);
 

--- a/src/commands/hot-reload.js
+++ b/src/commands/hot-reload.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 module.exports.run = async function(yuno, author, args, msg) {
     let reason = await yuno.hotreload();
 

--- a/src/commands/importbans.js
+++ b/src/commands/importbans.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const fs = require("fs").promises;
 const { setupRateLimitListener, waitForRateLimit } = require("../lib/rateLimitHelper");
 const { isValidSnowflake } = require("../lib/discordHelpers");

--- a/src/commands/inbox.js
+++ b/src/commands/inbox.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 /**
  * Format relative time
  */

--- a/src/commands/init-guild.js
+++ b/src/commands/init-guild.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 module.exports.runTerminal = async function(yuno, args) {
     if (args.length === 0 || isNaN(parseInt(args[0], 10)))
         return yuno.prompt.error("Please give the id of the guild in argument.")

--- a/src/commands/kick.js
+++ b/src/commands/kick.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const FAIL_COLOR = "#ff0000";
 const SUCCESS_COLOR = "#43cc24";
 

--- a/src/commands/list-command.js
+++ b/src/commands/list-command.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 module.exports.runTerminal = async function(yuno, args) {
     const commands = yuno.commandMan.commands;
     const uniqueCommands = {};

--- a/src/commands/list.js
+++ b/src/commands/list.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const EmbedCmdResponse = require("../lib/EmbedCmdResponse"),
     {EmbedBuilder} = require("discord.js");
 

--- a/src/commands/log-status.js
+++ b/src/commands/log-status.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const { EmbedBuilder } = require("discord.js");
 
 const LOG_TYPE_DESCRIPTIONS = {

--- a/src/commands/manga.js
+++ b/src/commands/manga.js
@@ -15,6 +15,9 @@
     You should have received a copy of the GNU Affero General Public License
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
+
+"use strict";
+
 const { ReactionCollector, EmbedBuilder } = require('discord.js');
 
 module.exports.run = async function(yuno, author, args, msg) {

--- a/src/commands/mass-addxp.js
+++ b/src/commands/mass-addxp.js
@@ -3,6 +3,9 @@
     ♥ Showering them with love... whether they want it or not~ ♥
 */
 
+"use strict";
+
+
 const { fetchNonBotMembers } = require("../lib/discordHelpers");
 
 module.exports.run = async function(yuno, author, args, trigger) {

--- a/src/commands/mass-levelup.js
+++ b/src/commands/mass-levelup.js
@@ -3,6 +3,9 @@
     ♥ They will rise exactly to your will. No more. No less. Forever bound~ ♥
 */
 
+"use strict";
+
+
 const { totalXPForLevel } = require("../lib/xpFormulas");
 
 module.exports.run = async function(yuno, author, args, trigger) {

--- a/src/commands/mass-setxp.js
+++ b/src/commands/mass-setxp.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const { fetchNonBotMembers } = require("../lib/discordHelpers");
 
 module.exports.run = async function(yuno, author, args, msg) {

--- a/src/commands/mentionresponses.js
+++ b/src/commands/mentionresponses.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const {EmbedBuilder} = require("discord.js");
 
 module.exports.run = async function(yuno, author, args, msg) {

--- a/src/commands/messages.js
+++ b/src/commands/messages.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const { ChannelType, PermissionsBitField } = require("discord.js");
 
 /**

--- a/src/commands/mod-stats.js
+++ b/src/commands/mod-stats.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const { EmbedBuilder, PermissionsBitField } = require("discord.js");
 const { withRateLimitHandling } = require("../lib/rateLimitHelper");
 

--- a/src/commands/neko.js
+++ b/src/commands/neko.js
@@ -15,6 +15,9 @@
     You should have received a copy of the GNU Affero General Public License
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
+
+"use strict";
+
 const {EmbedBuilder} = require('discord.js');
 
 module.exports.run = async function(yuno, author, args, msg) {

--- a/src/commands/ping.js
+++ b/src/commands/ping.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 module.exports.run = async function(yuno, author, args, msg) {
     if (author === 0)
         return yuno.prompt.info("Pong");

--- a/src/commands/praise.js
+++ b/src/commands/praise.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const praise = require('../data/praiseImages.json')
 
 module.exports.run = async function(yuno, author, args, msg) {

--- a/src/commands/quote.js
+++ b/src/commands/quote.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const quote = require('../data/quotes.json')
 
 module.exports.run = async function(yuno, author, args, msg) {

--- a/src/commands/reply.js
+++ b/src/commands/reply.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 module.exports.runTerminal = async function(yuno, args, rawInput, rl) {
     if (args.length < 1) {
         console.log("Usage: reply <inbox-id|user-id> [message]");

--- a/src/commands/scan-alts.js
+++ b/src/commands/scan-alts.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const { EmbedBuilder, ActionRowBuilder, StringSelectMenuBuilder } = require("discord.js");
 const { AltDetector } = require("discord-alt-detector");
 const { setupRateLimitListener, waitForRateLimit } = require("../lib/rateLimitHelper");

--- a/src/commands/scan-bans.js
+++ b/src/commands/scan-bans.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const { EmbedBuilder, AuditLogEvent } = require("discord.js");
 const { setupRateLimitListener, waitForRateLimit } = require("../lib/rateLimitHelper");
 const { fetchAllBannedUserIds } = require("../lib/discordHelpers");

--- a/src/commands/scold.js
+++ b/src/commands/scold.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const scold = require('../data/scoldImages.json')
 
 module.exports.run = async function(yuno, author, args, msg) {

--- a/src/commands/send.js
+++ b/src/commands/send.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const { ChannelType, PermissionsBitField } = require("discord.js");
 
 /**

--- a/src/commands/servers.js
+++ b/src/commands/servers.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const { PermissionsBitField } = require("discord.js");
 
 /**

--- a/src/commands/set-banimage.js
+++ b/src/commands/set-banimage.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const { resolveTargetMember } = require("../lib/discordHelpers");
 
 module.exports.run = async function(yuno, author, args, msg) {

--- a/src/commands/set-dm-channel.js
+++ b/src/commands/set-dm-channel.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const { ChannelType } = require("discord.js");
 
 module.exports.run = async function(yuno, author, args, msg) {

--- a/src/commands/set-experiencecounter.js
+++ b/src/commands/set-experiencecounter.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const { parseToggle } = require("../lib/parseToggle");
 
 module.exports.run = async function(yuno, author, args, msg) {

--- a/src/commands/set-joinmessage.js
+++ b/src/commands/set-joinmessage.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const {EmbedBuilder} = require("discord.js");
 
 module.exports.run = async function(yuno, author, args, msg) {

--- a/src/commands/set-level.js
+++ b/src/commands/set-level.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const {EmbedBuilder} = require("discord.js");
 const { xpNeededForLevel } = require("../lib/xpFormulas");
 

--- a/src/commands/set-levelrolemap.js
+++ b/src/commands/set-levelrolemap.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 module.exports.run = async function(yuno, author, args, msg) {
     if (args.length < 2)
         return msg.channel.send(":negative_squared_cross_mark: Not enough arguments. Usage: `set-levelrolemap <level> <@role>`");

--- a/src/commands/set-logchannel.js
+++ b/src/commands/set-logchannel.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const VALID_LOG_TYPES = ["unified", "voice", "nickname", "avatar", "presence"];
 
 module.exports.run = async function(yuno, author, args, msg) {

--- a/src/commands/set-logsettings.js
+++ b/src/commands/set-logsettings.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 module.exports.run = async function(yuno, author, args, msg) {
     if (args.length < 1) {
         const settings = await yuno.dbCommands.getLogSettings(yuno.database, msg.guild.id);

--- a/src/commands/set-prefix.js
+++ b/src/commands/set-prefix.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 module.exports.run = async function(yuno, author, args, msg) {
     let prefix = "!";
 

--- a/src/commands/set-presence.js
+++ b/src/commands/set-presence.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const { ActivityType } = require("discord.js");
 
 // Map string types to ActivityType enum

--- a/src/commands/set-spamfilter.js
+++ b/src/commands/set-spamfilter.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const { parseToggle } = require("../lib/parseToggle");
 
 module.exports.run = async function(yuno, author, args, msg) {

--- a/src/commands/set-vcxp.js
+++ b/src/commands/set-vcxp.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const { parseToggle } = require("../lib/parseToggle");
 
 module.exports.run = async function(yuno, author, args, msg) {

--- a/src/commands/shutdown.js
+++ b/src/commands/shutdown.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 let timeout = null;
 
 module.exports.runTerminal = async function(yuno, args) {

--- a/src/commands/source.js
+++ b/src/commands/source.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const {EmbedBuilder} = require("discord.js");
 
 module.exports.run = async function(yuno, author, args, msg) {

--- a/src/commands/stats.js
+++ b/src/commands/stats.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const totalMem = require("os").totalmem();
 const { version, EmbedBuilder } = require("discord.js");
 

--- a/src/commands/sync-levelroles.js
+++ b/src/commands/sync-levelroles.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const {EmbedBuilder} = require("discord.js");
 const { fetchNonBotMembers } = require("../lib/discordHelpers");
 

--- a/src/commands/sync-xp-from-roles.js
+++ b/src/commands/sync-xp-from-roles.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const {EmbedBuilder} = require("discord.js");
 const { fetchNonBotMembers } = require("../lib/discordHelpers");
 

--- a/src/commands/tban.js
+++ b/src/commands/tban.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const { isValidSnowflake } = require("../lib/discordHelpers");
 const { resolveGuildForTerminal } = require("../lib/terminalHelpers");
 

--- a/src/commands/texportbans.js
+++ b/src/commands/texportbans.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const fs = require("fs").promises;
 const path = require("path");
 const { isValidSnowflake, fetchAllBannedUserIds } = require("../lib/discordHelpers");

--- a/src/commands/timeout.js
+++ b/src/commands/timeout.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const { EmbedBuilder } = require("discord.js");
 const { ensureMembersInCache, parseModArgs } = require("../lib/discordHelpers");
 

--- a/src/commands/timportbans.js
+++ b/src/commands/timportbans.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const fs = require("fs").promises;
 const path = require("path");
 const { setupRateLimitListener, waitForRateLimit } = require("../lib/rateLimitHelper");

--- a/src/commands/tui.js
+++ b/src/commands/tui.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const tuiController = require('../lib/tui/index.js');
 
 module.exports.runTerminal = async function(yuno, args) {

--- a/src/commands/unban.js
+++ b/src/commands/unban.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const FAIL_COLOR = "#ff0000";
 const SUCCESS_COLOR = "#43cc24";
 

--- a/src/commands/urban.js
+++ b/src/commands/urban.js
@@ -13,6 +13,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const {EmbedBuilder} = require("discord.js");
 const urban = require("urban");
 

--- a/src/commands/vcxp-status.js
+++ b/src/commands/vcxp-status.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const { EmbedBuilder } = require("discord.js");
 
 module.exports.run = async function(yuno, author, args, msg) {

--- a/src/commands/watch.js
+++ b/src/commands/watch.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const { ChannelType, PermissionsBitField } = require("discord.js");
 
 // Track active watch sessions

--- a/src/commands/xp.js
+++ b/src/commands/xp.js
@@ -13,6 +13,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const {EmbedBuilder} = require("discord.js");
 const { ensureMembersInCache } = require("../lib/discordHelpers");
 const { xpNeededForLevel } = require("../lib/xpFormulas");

--- a/src/database.js
+++ b/src/database.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 // Database driver detection - priority: native SQLite > sqlcipher > sqlite3
 let sqlite;
 let encryptionAvailable = false;
@@ -23,7 +26,7 @@ let useNativeSQLite = false;
 let DatabaseImpl;
 
 // Field-level encryption support
-const { createEncryptionHelper } = require('./lib/cryptoUtils');
+const { createEncryptionHelper, createEncryptionHelperAsync } = require('./lib/cryptoUtils');
 
 // Try Node.js 24+ native SQLite first
 try {
@@ -66,14 +69,14 @@ class NativeDatabase {
     }
 
     /**
-     * Enable field-level encryption with the given passphrase
+     * Enable field-level encryption with the given passphrase.
+     * Derives the master key asynchronously (once) so subsequent
+     * encrypt/decrypt calls are fast synchronous AES operations.
      * @param {string} passphrase - The encryption passphrase
      */
-    setFieldEncryptionKey(passphrase) {
-        this.fieldEncryption = createEncryptionHelper(passphrase);
-        if (this.fieldEncryption.enabled) {
-            console.log("[Database] Field-level encryption enabled");
-        }
+    async setFieldEncryptionKey(passphrase) {
+        this.fieldEncryption = await createEncryptionHelperAsync(passphrase);
+        console.log("[Database] Field-level encryption enabled (v2 format, master key cached)");
     }
 
     /**
@@ -386,14 +389,14 @@ class LegacyDatabase {
     }
 
     /**
-     * Enable field-level encryption with the given passphrase
+     * Enable field-level encryption with the given passphrase.
+     * Derives the master key asynchronously (once) so subsequent
+     * encrypt/decrypt calls are fast synchronous AES operations.
      * @param {string} passphrase - The encryption passphrase
      */
-    setFieldEncryptionKey(passphrase) {
-        this.fieldEncryption = createEncryptionHelper(passphrase);
-        if (this.fieldEncryption.enabled) {
-            console.log("[Database] Field-level encryption enabled");
-        }
+    async setFieldEncryptionKey(passphrase) {
+        this.fieldEncryption = await createEncryptionHelperAsync(passphrase);
+        console.log("[Database] Field-level encryption enabled (v2 format, master key cached)");
     }
 
     /**

--- a/src/lib/EmbedCmdResponse.js
+++ b/src/lib/EmbedCmdResponse.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 // hot-reload
 delete require.cache[require.resolve("../Util")]
 

--- a/src/lib/commandManager.js
+++ b/src/lib/commandManager.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const EventEmitter = require("events"),
     fsPromises = require("fs").promises,
     path = require("path"),

--- a/src/lib/configManager.js
+++ b/src/lib/configManager.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const fs = require("fs"),
     fsPromises = require("fs").promises;
 

--- a/src/lib/cryptoUtils.js
+++ b/src/lib/cryptoUtils.js
@@ -16,131 +16,179 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
 /**
  * Field-level encryption utilities using Node.js built-in crypto.
  * Provides AES-256-GCM encryption for sensitive database fields.
  *
- * This is an alternative to SQLCipher when using Node.js 24 native SQLite,
- * which doesn't support database-level encryption.
+ * Format versions
+ * ---------------
+ * V1 (legacy): salt(16) + iv(16) + authTag(16) + ciphertext
+ *   - PBKDF2 was run on EVERY encrypt/decrypt call (100k iterations each).
+ *   - Still supported for decryption of existing data.
+ *
+ * V2 (current): MAGIC(4) + iv(12) + authTag(16) + ciphertext
+ *   - Master key is derived ONCE at startup via async PBKDF2, then cached.
+ *   - Encrypt/decrypt calls are fast synchronous AES-256-GCM operations.
+ *   - Migration: any V1 ciphertext is automatically returned in V2 format when
+ *     re-encrypted (e.g. via a migration script).
  */
 
 const crypto = require('crypto');
 
 const ALGORITHM = 'aes-256-gcm';
-const IV_LENGTH = 16;
 const AUTH_TAG_LENGTH = 16;
-const SALT_LENGTH = 16;
 const KEY_ITERATIONS = 100000;
+const KEY_DIGEST = 'sha256';
+
+// V2 format constants
+const V2_MAGIC = Buffer.from([0x59, 0x4E, 0x02, 0x00]); // "YN\x02\x00"
+const V2_IV_LENGTH = 12; // GCM recommended nonce size
+
+// V1 (legacy) format constants
+const V1_SALT_LENGTH = 16;
+const V1_IV_LENGTH = 16;
+const V1_MIN_LENGTH = V1_SALT_LENGTH + V1_IV_LENGTH + AUTH_TAG_LENGTH + 1; // 49
 
 /**
- * Derives a 32-byte key from a passphrase using PBKDF2
- * @param {string} passphrase - The passphrase to derive from
- * @param {Buffer} salt - Salt for key derivation
- * @returns {Buffer} 32-byte key
+ * Derives the V2 master key from a passphrase.
+ * The PBKDF2 salt is deterministic from the passphrase so no external salt
+ * storage is required. Security relies entirely on passphrase secrecy.
+ * This runs ONCE at startup — all subsequent encryptions use the cached key.
+ * @param {string} passphrase
+ * @returns {Promise<Buffer>} 32-byte master key
  */
-function deriveKey(passphrase, salt) {
-    return crypto.pbkdf2Sync(passphrase, salt, KEY_ITERATIONS, 32, 'sha256');
+async function deriveMasterKey(passphrase) {
+    const salt = crypto.createHash('sha256')
+        .update('yuno-gasai-field-encryption-v2-salt:')
+        .update(passphrase)
+        .digest();
+    return new Promise((resolve, reject) => {
+        crypto.pbkdf2(passphrase, salt, KEY_ITERATIONS, 32, KEY_DIGEST, (err, key) => {
+            if (err) reject(err);
+            else resolve(key);
+        });
+    });
 }
 
 /**
- * Encrypts a string using AES-256-GCM
- * @param {string|null} plaintext - The text to encrypt
- * @param {string} passphrase - The encryption passphrase
- * @returns {string|null} Base64 encoded encrypted data (salt + iv + authTag + ciphertext) or null
+ * Legacy synchronous key derivation — used ONLY when decrypting V1 ciphertexts
+ * (backward compatibility path). New data is never written in V1 format.
  */
-function encrypt(plaintext, passphrase) {
-    if (plaintext === null || plaintext === undefined) {
-        return null;
-    }
+function _deriveKeyLegacySync(passphrase, salt) {
+    return crypto.pbkdf2Sync(passphrase, salt, KEY_ITERATIONS, 32, KEY_DIGEST);
+}
 
-    const text = String(plaintext);
-    const salt = crypto.randomBytes(SALT_LENGTH);
-    const key = deriveKey(passphrase, salt);
-    const iv = crypto.randomBytes(IV_LENGTH);
-
-    const cipher = crypto.createCipheriv(ALGORITHM, key, iv);
-    const encrypted = Buffer.concat([cipher.update(text, 'utf8'), cipher.final()]);
+/** Encrypt a plaintext string using the V2 format (fast — no KDF per call). */
+function _encryptV2(text, masterKey) {
+    const iv = crypto.randomBytes(V2_IV_LENGTH);
+    const cipher = crypto.createCipheriv(ALGORITHM, masterKey, iv);
+    const ciphertext = Buffer.concat([cipher.update(String(text), 'utf8'), cipher.final()]);
     const authTag = cipher.getAuthTag();
+    return Buffer.concat([V2_MAGIC, iv, authTag, ciphertext]).toString('base64');
+}
 
-    // Format: salt (16) + iv (16) + authTag (16) + ciphertext
-    const result = Buffer.concat([salt, iv, authTag, encrypted]);
-    return result.toString('base64');
+/** Decrypt a V2 ciphertext (fast — no KDF per call). */
+function _decryptV2(buf, masterKey) {
+    const iv = buf.slice(V2_MAGIC.length, V2_MAGIC.length + V2_IV_LENGTH);
+    const authTag = buf.slice(V2_MAGIC.length + V2_IV_LENGTH, V2_MAGIC.length + V2_IV_LENGTH + AUTH_TAG_LENGTH);
+    const ciphertext = buf.slice(V2_MAGIC.length + V2_IV_LENGTH + AUTH_TAG_LENGTH);
+    const decipher = crypto.createDecipheriv(ALGORITHM, masterKey, iv);
+    decipher.setAuthTag(authTag);
+    return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8');
+}
+
+/** Decrypt a V1 ciphertext synchronously (legacy backward-compat path). */
+function _decryptV1Legacy(buf, passphrase) {
+    const salt = buf.slice(0, V1_SALT_LENGTH);
+    const iv = buf.slice(V1_SALT_LENGTH, V1_SALT_LENGTH + V1_IV_LENGTH);
+    const authTag = buf.slice(V1_SALT_LENGTH + V1_IV_LENGTH, V1_SALT_LENGTH + V1_IV_LENGTH + AUTH_TAG_LENGTH);
+    const ciphertext = buf.slice(V1_SALT_LENGTH + V1_IV_LENGTH + AUTH_TAG_LENGTH);
+    const key = _deriveKeyLegacySync(passphrase, salt);
+    const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
+    decipher.setAuthTag(authTag);
+    return Buffer.concat([decipher.update(ciphertext), decipher.final()]).toString('utf8');
 }
 
 /**
- * Decrypts a string encrypted with encrypt()
- * @param {string|null} encryptedData - Base64 encoded encrypted data
- * @param {string} passphrase - The encryption passphrase
- * @returns {string|null} Decrypted plaintext or original value if decryption fails
+ * Creates an async encryption helper that derives the master key once.
+ * The returned object has SYNCHRONOUS encrypt() and decrypt() methods
+ * that use the cached master key — no event-loop blocking per call.
+ * @param {string} passphrase
+ * @returns {Promise<{enabled: boolean, encrypt: Function, decrypt: Function}>}
  */
-function decrypt(encryptedData, passphrase) {
-    if (encryptedData === null || encryptedData === undefined) {
-        return null;
-    }
+async function createEncryptionHelperAsync(passphrase) {
+    const masterKey = await deriveMasterKey(passphrase);
 
-    try {
-        const buffer = Buffer.from(encryptedData, 'base64');
+    return {
+        enabled: true,
+        encrypt(value) {
+            if (value === null || value === undefined) return null;
+            return _encryptV2(value, masterKey);
+        },
+        decrypt(value) {
+            if (value === null || value === undefined) return null;
+            try {
+                const buf = Buffer.from(value, 'base64');
 
-        // Minimum size check: salt (16) + iv (16) + authTag (16) + at least 1 byte ciphertext
-        if (buffer.length < 49) {
-            // Too short to be encrypted data, return as-is (legacy unencrypted data)
-            return encryptedData;
+                // V2 format: starts with magic bytes
+                const minV2 = V2_MAGIC.length + V2_IV_LENGTH + AUTH_TAG_LENGTH + 1;
+                if (buf.length >= minV2 && buf.slice(0, V2_MAGIC.length).equals(V2_MAGIC)) {
+                    return _decryptV2(buf, masterKey);
+                }
+
+                // V1 (legacy) format: salt + iv + authTag + ciphertext
+                if (buf.length >= V1_MIN_LENGTH) {
+                    return _decryptV1Legacy(buf, passphrase);
+                }
+
+                // Too short to be encrypted — return as-is (unencrypted legacy data)
+                return value;
+            } catch {
+                return value;
+            }
         }
-
-        const salt = buffer.slice(0, SALT_LENGTH);
-        const iv = buffer.slice(SALT_LENGTH, SALT_LENGTH + IV_LENGTH);
-        const authTag = buffer.slice(SALT_LENGTH + IV_LENGTH, SALT_LENGTH + IV_LENGTH + AUTH_TAG_LENGTH);
-        const ciphertext = buffer.slice(SALT_LENGTH + IV_LENGTH + AUTH_TAG_LENGTH);
-
-        const key = deriveKey(passphrase, salt);
-
-        const decipher = crypto.createDecipheriv(ALGORITHM, key, iv);
-        decipher.setAuthTag(authTag);
-
-        const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()]);
-        return decrypted.toString('utf8');
-    } catch (err) {
-        // If decryption fails, it might be unencrypted legacy data
-        // Return the original value
-        return encryptedData;
-    }
+    };
 }
 
 /**
- * Checks if a value appears to be encrypted (base64 with correct minimum length)
- * @param {string} value - Value to check
+ * Creates a no-op (encryption-disabled) helper synchronously.
+ * Used as the initial state before setFieldEncryptionKey is called.
+ * @returns {{enabled: boolean, encrypt: Function, decrypt: Function}}
+ */
+function createEncryptionHelper(passphrase) {
+    if (passphrase !== null && passphrase !== undefined && passphrase.length > 0) {
+        throw new Error("Use createEncryptionHelperAsync() for encrypted helpers — it derives the key asynchronously to avoid blocking the event loop.");
+    }
+    return {
+        enabled: false,
+        encrypt: (value) => value,
+        decrypt: (value) => value
+    };
+}
+
+/**
+ * Checks if a value appears to be encrypted in either V1 or V2 format.
+ * @param {string} value
  * @returns {boolean}
  */
 function isEncrypted(value) {
     if (typeof value !== 'string') return false;
     try {
-        const buffer = Buffer.from(value, 'base64');
-        // Minimum size: salt (16) + iv (16) + authTag (16) + 1 (min ciphertext)
-        return buffer.length >= 49;
+        const buf = Buffer.from(value, 'base64');
+        const minV2 = V2_MAGIC.length + V2_IV_LENGTH + AUTH_TAG_LENGTH + 1;
+        if (buf.length >= minV2 && buf.slice(0, V2_MAGIC.length).equals(V2_MAGIC)) return true;
+        return buf.length >= V1_MIN_LENGTH;
     } catch {
         return false;
     }
 }
 
-/**
- * Creates an encryption helper bound to a specific passphrase
- * @param {string|null} passphrase - The encryption passphrase (null to disable)
- * @returns {Object} Object with encrypt and decrypt methods
- */
-function createEncryptionHelper(passphrase) {
-    const enabled = passphrase !== null && passphrase !== undefined && passphrase.length > 0;
-
-    return {
-        enabled,
-        encrypt: enabled ? (value) => encrypt(value, passphrase) : (value) => value,
-        decrypt: enabled ? (value) => decrypt(value, passphrase) : (value) => value
-    };
-}
-
 module.exports = {
-    encrypt,
-    decrypt,
+    createEncryptionHelper,
+    createEncryptionHelperAsync,
     isEncrypted,
-    deriveKey,
-    createEncryptionHelper
+    // Exported for db-integrity-check.js backward-compat (legacy decryption only)
+    _deriveKeyLegacySync,
 };

--- a/src/lib/discordHelpers.js
+++ b/src/lib/discordHelpers.js
@@ -6,6 +6,9 @@ const { PermissionsBitField } = require("discord.js");
  * @param {import("discord.js").Message} msg
  * @param {import("discord.js").Client} client
  */
+
+"use strict";
+
 async function ensureMembersInCache(msg, client) {
     if (msg.guild && !msg.guild.members.cache.has(msg.author.id) && !msg.webhookId) {
         msg.member = await msg.guild.members.fetch(msg.author);

--- a/src/lib/interactiveTerm.js
+++ b/src/lib/interactiveTerm.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const EventEmitter = require("events"),
     readline = require("readline"),
     prompt = (require("./prompt")).init();

--- a/src/lib/intervalManager.js
+++ b/src/lib/intervalManager.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 let instance = null;
 
 /**

--- a/src/lib/lruCache.js
+++ b/src/lib/lruCache.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 /**
  * Simple LRU (Least Recently Used) Cache implementation
  * @param {number} maxSize Maximum number of entries in the cache

--- a/src/lib/parseToggle.js
+++ b/src/lib/parseToggle.js
@@ -5,6 +5,9 @@
  * @param {string} str
  * @returns {boolean|null}
  */
+
+"use strict";
+
 function parseToggle(str) {
     if (!str || typeof str !== "string") return null;
     const lower = str.toLowerCase();

--- a/src/lib/prompt.COLORS.js
+++ b/src/lib/prompt.COLORS.js
@@ -1,3 +1,5 @@
+"use strict";
+
 module.exports = {
     "RESET": "\x1b[0m",
     "BRIGHT": "\x1b[1m",

--- a/src/lib/prompt.js
+++ b/src/lib/prompt.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const readline = require("readline"),
 
     GROUPWIDTH = 10;

--- a/src/lib/rateLimitHelper.js
+++ b/src/lib/rateLimitHelper.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 /**
  * Rate limit helper for Discord API operations
  * Provides dynamic delay calculation based on rate limit events

--- a/src/lib/terminalHelpers.js
+++ b/src/lib/terminalHelpers.js
@@ -6,6 +6,9 @@
  * @param {string} [requiredPermission="BanMembers"] - Permission flag name
  * @returns {import("discord.js").Guild|null}
  */
+
+"use strict";
+
 function resolveGuildForTerminal(yuno, serverId, requiredPermission = "BanMembers") {
     if (!/^\d{17,19}$/.test(serverId)) {
         console.log("Error: Invalid server ID format.");

--- a/src/lib/tui/channelTree.js
+++ b/src/lib/tui/channelTree.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const blessed = require('neo-blessed');
 const { ChannelType } = require('discord.js');
 

--- a/src/lib/tui/chatPane.js
+++ b/src/lib/tui/chatPane.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const blessed = require('neo-blessed');
 
 function formatTime(date) {

--- a/src/lib/tui/commandBridge.js
+++ b/src/lib/tui/commandBridge.js
@@ -1,3 +1,5 @@
+"use strict";
+
 async function captureLog(fn) {
     const lines = [];
     const orig = console.log;

--- a/src/lib/tui/hintBar.js
+++ b/src/lib/tui/hintBar.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const blessed = require('neo-blessed');
 
 const HINT_TEXT = '  Tab:Focus  PgUp/Dn:Scroll  Alt+M:Members  Ctrl+Q:Quit  :shortcuts  Alt+H:Hide';

--- a/src/lib/tui/index.js
+++ b/src/lib/tui/index.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const MessageCache = require('./messageCache.js');
 const { buildLayout } = require('./layout.js');
 

--- a/src/lib/tui/inputBar.js
+++ b/src/lib/tui/inputBar.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const blessed = require('neo-blessed');
 const { runCommand } = require('./commandBridge.js');
 

--- a/src/lib/tui/layout.js
+++ b/src/lib/tui/layout.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const blessed = require('neo-blessed');
 const { createStatusBar }   = require('./statusBar.js');
 const { createHintBar }     = require('./hintBar.js');

--- a/src/lib/tui/membersPane.js
+++ b/src/lib/tui/membersPane.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const blessed = require('neo-blessed');
 
 function createMembersPane(screen) {

--- a/src/lib/tui/messageCache.js
+++ b/src/lib/tui/messageCache.js
@@ -1,3 +1,5 @@
+"use strict";
+
 class MessageCache {
     constructor() {
         this._messages = new Map();

--- a/src/lib/tui/statusBar.js
+++ b/src/lib/tui/statusBar.js
@@ -1,3 +1,5 @@
+"use strict";
+
 const blessed = require('neo-blessed');
 
 function createStatusBar(screen) {

--- a/src/lib/xpFormulas.js
+++ b/src/lib/xpFormulas.js
@@ -4,6 +4,9 @@
  * @param {number} level - Current level (0-based)
  * @returns {number}
  */
+
+"use strict";
+
 function xpNeededForLevel(level) {
     return 5 * Math.pow(level, 2) + 50 * level + 100;
 }

--- a/src/message-processors/custom-spam-rules/447665600135823361.js
+++ b/src/message-processors/custom-spam-rules/447665600135823361.js
@@ -2,6 +2,9 @@
     Yuno Gasai. A Discord.JS based bot, with multiple features.
     Copyright (C) 2018 Maeeen <maeeennn@gmail.com>
 */
+
+"use strict";
+
 const { EmbedBuilder, PermissionsBitField } = require("discord.js");
 const crypto = require("crypto");
 

--- a/src/message-processors/experience.js
+++ b/src/message-processors/experience.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const { xpNeededForLevel } = require("../lib/xpFormulas");
 
 module.exports.messageProcName = "experience"

--- a/src/message-processors/mention-responses.js
+++ b/src/message-processors/mention-responses.js
@@ -1,3 +1,5 @@
+"use strict";
+
 module.exports.messageProcName = "mention-responses"
 
 const {EmbedBuilder} = require("discord.js");

--- a/src/message-processors/spamfilter.js
+++ b/src/message-processors/spamfilter.js
@@ -13,6 +13,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 module.exports.messageProcName = "spam-filter"
 
 const { ensureMembersInCache } = require("../lib/discordHelpers");

--- a/src/modules/activity-logger.js
+++ b/src/modules/activity-logger.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 module.exports.modulename = "activity-logger";
 
 const { EmbedBuilder } = require("discord.js");

--- a/src/modules/alt-detector.js
+++ b/src/modules/alt-detector.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const { EmbedBuilder } = require("discord.js");
 const { AltDetector } = require("discord-alt-detector");
 

--- a/src/modules/auto-cleaner.js
+++ b/src/modules/auto-cleaner.js
@@ -12,6 +12,9 @@
     You should have received a copy of the GNU Affero General Public License
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
+
+"use strict";
+
 const { Guild, EmbedBuilder } = require("discord.js");
 
 let intervalManager = null;

--- a/src/modules/auto-role-restore.js
+++ b/src/modules/auto-role-restore.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 module.exports.modulename = "auto-role-restore";
 
 let DISCORD_EVENTED = false,

--- a/src/modules/auto-update-checker.js
+++ b/src/modules/auto-update-checker.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const { execFile } = require("child_process");
 const { promisify } = require("util");
 const execFileAsync = promisify(execFile);

--- a/src/modules/bot-errors.js
+++ b/src/modules/bot-errors.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 let channelName = null,
     guildId = null,
     guild = null,

--- a/src/modules/command-executor.js
+++ b/src/modules/command-executor.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 let workOnlyOnGuild = null,
     defaultPrefix = null,
     prefixes = null,

--- a/src/modules/dm-handler.js
+++ b/src/modules/dm-handler.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 module.exports.modulename = "dm-handler";
 
 const { EmbedBuilder } = require("discord.js");

--- a/src/modules/invite-deletor.js
+++ b/src/modules/invite-deletor.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 module.exports.modulename = "invite-deletor";
 
 let DISCORD_EVENTED = false;

--- a/src/modules/join-dm-msg.js
+++ b/src/modules/join-dm-msg.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 let {EmbedBuilder} = require("discord.js"),
     embedColor = "#ff7ab3";
 

--- a/src/modules/message-processors.js
+++ b/src/modules/message-processors.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const fsPromises = require("fs").promises;
 
 let workOnlyOnGuild = null,

--- a/src/modules/presence.js
+++ b/src/modules/presence.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const { ActivityType } = require('discord.js');
 
 module.exports.modulename = "presence";

--- a/src/modules/slash-commands.js
+++ b/src/modules/slash-commands.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 const { SlashCommandBuilder, REST, Routes, PermissionFlagsBits } = require("discord.js");
 
 let Yuno = null;

--- a/src/modules/vc-xp.js
+++ b/src/modules/vc-xp.js
@@ -16,6 +16,9 @@
     along with this program.  If not, see https://www.gnu.org/licenses/.
 */
 
+"use strict";
+
+
 module.exports.modulename = "vc-xp";
 
 let DISCORD_EVENTED = false,

--- a/src/scripts/db-integrity-check.js
+++ b/src/scripts/db-integrity-check.js
@@ -133,41 +133,80 @@ function runSql(sql, params = []) {
 
 // ---------------------------------------------------------------------------
 // Field-level decryption (mirrors src/lib/cryptoUtils.js)
+// Supports both V1 (legacy per-call PBKDF2) and V2 (master key) formats.
 // ---------------------------------------------------------------------------
 
 const ALGORITHM      = "aes-256-gcm";
-const IV_LENGTH      = 16;
 const AUTH_TAG_LEN   = 16;
-const SALT_LENGTH    = 16;
 const KEY_ITERATIONS = 100_000;
+
+// V2 format constants
+const V2_MAGIC    = Buffer.from([0x59, 0x4E, 0x02, 0x00]);
+const V2_IV_LEN   = 12;
+
+// V1 (legacy) format constants
+const V1_SALT_LEN = 16;
+const V1_IV_LEN   = 16;
+const V1_MIN_LEN  = V1_SALT_LEN + V1_IV_LEN + AUTH_TAG_LEN + 1; // 49
+
+// Cached V2 master keys by passphrase (derived once per script run)
+const _masterKeyCache = new Map();
+
+function _getMasterKeySync(passphrase) {
+    if (_masterKeyCache.has(passphrase)) return _masterKeyCache.get(passphrase);
+    const salt = crypto.createHash("sha256")
+        .update("yuno-gasai-field-encryption-v2-salt:")
+        .update(passphrase)
+        .digest();
+    const key = crypto.pbkdf2Sync(passphrase, salt, KEY_ITERATIONS, 32, "sha256");
+    _masterKeyCache.set(passphrase, key);
+    return key;
+}
 
 function _tryDecrypt(encryptedData, passphrase) {
     if (!passphrase || encryptedData === null || encryptedData === undefined) return encryptedData;
     try {
         const buf = Buffer.from(encryptedData, "base64");
-        if (buf.length < 49) return encryptedData; // not encrypted (legacy)
-        const salt    = buf.slice(0, SALT_LENGTH);
-        const iv      = buf.slice(SALT_LENGTH, SALT_LENGTH + IV_LENGTH);
-        const authTag = buf.slice(SALT_LENGTH + IV_LENGTH, SALT_LENGTH + IV_LENGTH + AUTH_TAG_LEN);
-        const cipher  = buf.slice(SALT_LENGTH + IV_LENGTH + AUTH_TAG_LEN);
-        const key     = crypto.pbkdf2Sync(passphrase, salt, KEY_ITERATIONS, 32, "sha256");
-        const dec     = crypto.createDecipheriv(ALGORITHM, key, iv);
-        dec.setAuthTag(authTag);
-        return Buffer.concat([dec.update(cipher), dec.final()]).toString("utf8");
+
+        // V2 format: starts with magic bytes
+        const minV2 = V2_MAGIC.length + V2_IV_LEN + AUTH_TAG_LEN + 1;
+        if (buf.length >= minV2 && buf.slice(0, V2_MAGIC.length).equals(V2_MAGIC)) {
+            const masterKey = _getMasterKeySync(passphrase);
+            const iv      = buf.slice(V2_MAGIC.length, V2_MAGIC.length + V2_IV_LEN);
+            const authTag = buf.slice(V2_MAGIC.length + V2_IV_LEN, V2_MAGIC.length + V2_IV_LEN + AUTH_TAG_LEN);
+            const cipher  = buf.slice(V2_MAGIC.length + V2_IV_LEN + AUTH_TAG_LEN);
+            const dec = crypto.createDecipheriv(ALGORITHM, masterKey, iv);
+            dec.setAuthTag(authTag);
+            return Buffer.concat([dec.update(cipher), dec.final()]).toString("utf8");
+        }
+
+        // V1 (legacy) format: salt + iv + authTag + ciphertext
+        if (buf.length >= V1_MIN_LEN) {
+            const salt    = buf.slice(0, V1_SALT_LEN);
+            const iv      = buf.slice(V1_SALT_LEN, V1_SALT_LEN + V1_IV_LEN);
+            const authTag = buf.slice(V1_SALT_LEN + V1_IV_LEN, V1_SALT_LEN + V1_IV_LEN + AUTH_TAG_LEN);
+            const cipher  = buf.slice(V1_SALT_LEN + V1_IV_LEN + AUTH_TAG_LEN);
+            const key     = crypto.pbkdf2Sync(passphrase, salt, KEY_ITERATIONS, 32, "sha256");
+            const dec     = crypto.createDecipheriv(ALGORITHM, key, iv);
+            dec.setAuthTag(authTag);
+            return Buffer.concat([dec.update(cipher), dec.final()]).toString("utf8");
+        }
+
+        return encryptedData; // Too short — unencrypted legacy data
     } catch {
         return encryptedData; // leave as-is if decryption fails
     }
 }
 
 function _tryEncrypt(plaintext, passphrase) {
+    // Re-encryption uses V2 format (no per-call KDF)
     if (!passphrase || plaintext === null || plaintext === undefined) return plaintext;
-    const salt = crypto.randomBytes(SALT_LENGTH);
-    const key  = crypto.pbkdf2Sync(passphrase, salt, KEY_ITERATIONS, 32, "sha256");
-    const iv   = crypto.randomBytes(IV_LENGTH);
-    const enc  = crypto.createCipheriv(ALGORITHM, key, iv);
+    const masterKey = _getMasterKeySync(passphrase);
+    const iv  = crypto.randomBytes(V2_IV_LEN);
+    const enc = crypto.createCipheriv(ALGORITHM, masterKey, iv);
     const encrypted = Buffer.concat([enc.update(String(plaintext), "utf8"), enc.final()]);
     const authTag = enc.getAuthTag();
-    return Buffer.concat([salt, iv, authTag, encrypted]).toString("base64");
+    return Buffer.concat([V2_MAGIC, iv, authTag, encrypted]).toString("base64");
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Event loop blocking fixed**: `crypto.pbkdf2Sync` was called on every field encrypt/decrypt (100k iterations each, ~100ms per call). Redesigned `cryptoUtils.js` to derive a master key **once** at startup via async `crypto.pbkdf2()` and cache it. All subsequent field encryptions/decryptions are now fast synchronous AES-256-GCM operations with no KDF overhead per call.
- **Ciphertext format V2**: New format uses a 4-byte magic header (`YN\x02\x00`) + 12-byte GCM-optimal IV. V1 (legacy) ciphertexts are still decrypted transparently for backward compatibility.
- **`setFieldEncryptionKey` is now async** in both `NativeDatabase` and `LegacyDatabase`; `Yuno.js` awaits it at startup.
- **EventEmitter error handler**: `ModuleExporter.hrReference()` returned a bare `EventEmitter` with no `.on('error')` listener — an emitted error event would throw as an uncaught exception and crash the process. Error handler added.
- **`"use strict"` in all 125 source files** that were missing it — catches implicit globals, silent type coercions, and duplicate keys at parse time rather than at runtime.
- **`db-integrity-check.js`** updated to understand V2 format; master key derived once per script run via `pbkdf2Sync` (acceptable in a CLI tool) and cached.

## Test plan
- [ ] Start bot with field encryption enabled — confirm `[Database] Field-level encryption enabled (v2 format, master key cached)` appears in logs
- [ ] Write a mention response, restart bot, confirm it decrypts correctly (V2 round-trip)
- [ ] If you have existing V1-encrypted data, confirm it still decrypts (backward compat path)
- [ ] Run `npm run check-db -- --passphrase=<key>` and confirm V2-format fields are recognised
- [ ] Hot-reload a module; confirm no uncaught exception from the EventEmitter error path

🤖 Generated with [Claude Code](https://claude.com/claude-code)