### PR TITLE
Security: remove eval, ReDoS fixes, ESLint, --permission, event loop monitor

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,0 +1,46 @@
+import js from "@eslint/js";
+import security from "eslint-plugin-security";
+
+export default [
+    js.configs.recommended,
+    security.configs.recommended,
+    {
+        rules: {
+            // Dangerous function execution
+            "no-eval": "error",
+            "no-implied-eval": "error",
+            "no-new-func": "error",
+
+            // Prototype pollution guards
+            "no-proto": "error",
+            "no-extend-native": "error",
+
+            // Catch obvious mistakes that strict mode may not cover
+            "no-var": "warn",
+            "prefer-const": "warn",
+
+            // Allow console in a CLI/bot context
+            "no-console": "off",
+        },
+        languageOptions: {
+            ecmaVersion: 2022,
+            sourceType: "commonjs",
+            globals: {
+                require: "readonly",
+                module: "readonly",
+                exports: "readonly",
+                __dirname: "readonly",
+                __filename: "readonly",
+                process: "readonly",
+                Buffer: "readonly",
+                setInterval: "readonly",
+                setTimeout: "readonly",
+                clearInterval: "readonly",
+                clearTimeout: "readonly",
+                setImmediate: "readonly",
+                console: "readonly",
+            }
+        },
+        ignores: ["node_modules/**", "docs/**"],
+    }
+];

--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
   "main": "index.js",
   "type": "commonjs",
   "scripts": {
-    "start": "node --experimental-sqlite index.js",
-    "start:legacy": "node index.js",
+    "start": "node --experimental-sqlite --permission --allow-fs-read=. --allow-fs-write=. --allow-child-process index.js",
+    "start:legacy": "node --permission --allow-fs-read=. --allow-fs-write=. --allow-child-process index.js",
     "dev": "node --experimental-sqlite index.js --hot-reload",
     "test": "node --test",
+    "lint": "eslint src/",
     "generate-doc": "jsdoc .\\src -r -p -d docs -t node_modules/docdash",
     "generate-doc-notheme": "jsdoc .\\src -r -p -d docs",
     "check-db": "node --experimental-sqlite src/scripts/db-integrity-check.js",
@@ -18,7 +19,10 @@
     "node": ">=24.0.0"
   },
   "devDependencies": {
-    "docdash": ">=2.0.2"
+    "docdash": ">=2.0.2",
+    "eslint": "^9.0.0",
+    "@eslint/js": "^9.0.0",
+    "eslint-plugin-security": "^3.0.0"
   },
   "dependencies": {
     "discord-alt-detector": "^1.0.4",

--- a/src/Util.js
+++ b/src/Util.js
@@ -168,8 +168,8 @@ module.exports = {
         }
         str = str
             .replace(/\n\n/g, '\n')
-            .replace(/\[.*\]/g, '')
-            .replace(/\(Source: .*\)/g, '');
+            .replace(/\[[^\]]*\]/g, '')
+            .replace(/\(Source: [^)]*\)/g, '');
 
         return str;
     }

--- a/src/Yuno.js
+++ b/src/Yuno.js
@@ -42,6 +42,22 @@ let ModuleExporter = (require("./ModuleExporter.js")).init(),
 
 let ONETIME_EVENT = false
 
+// Event loop lag monitor — warns if the loop was blocked for > 100ms.
+// Uses .unref() so it does not prevent a clean process exit.
+const _EL_INTERVAL_MS = 1000;
+const _EL_LAG_THRESHOLD_MS = 100;
+function _startEventLoopMonitor(prompt) {
+    let last = Date.now();
+    setInterval(() => {
+        const now = Date.now();
+        const lag = now - last - _EL_INTERVAL_MS;
+        last = now;
+        if (lag > _EL_LAG_THRESHOLD_MS) {
+            prompt.warn(`[EventLoop] Blocked for ~${lag}ms — check for synchronous I/O or heavy CPU work.`);
+        }
+    }, _EL_INTERVAL_MS).unref();
+}
+
 // Connection state tracking for auto-reconnection
 let connectionState = {
     isConnected: false,
@@ -242,9 +258,6 @@ class Yuno extends EventEmitter {
                 "aliases": ["-noit"],
                 "description": "Removes the interactions with the terminal."
             }, {
-                "argument": "--debug-script",
-                "description": "Evalutes debug-script.js when ready."
-            }, {
                 "argument": "--upgrade-database=v1yunodb.db;destination.db",
                 "description": "Updates the Yuno's 1st version database to the Yuno's 2nd database"
             }, {
@@ -260,18 +273,6 @@ class Yuno extends EventEmitter {
                 "description": "Start in full terminal UI mode (XChat-style)."
             }
         ])
-    }
-
-    /**
-     * Evals a code under with the Yuno's context.
-     * @param {String} code
-     * @warning Don't provide any shit to this method.
-     * @async
-     * @returns {any} The result of the "eval"
-     * @private
-     */
-    _eval(code) {
-        return eval(code)
     }
 
     /**
@@ -439,17 +440,6 @@ ${YUNO_PINK}           "I'll protect this server forever... just for you~"${RESE
                 test: (arg) => arg.startsWith("--hot-reload") || arg.startsWith("-hr"),
                 handle: (arg) => {
                     prompt.debug("Hot-Reload enabled on " + ModuleExporter.watch(arg.split("=")[1] ?? undefined));
-                }
-            },
-            debugScript: {
-                test: (arg) => arg === "--debug-script",
-                handle: () => {
-                    this.on("ready", () => {
-                        require("fs").readFile("./debug-script.js", "utf8", (err, data) => {
-                            this._eval(data);
-                            prompt.info("Debug-script loaded.");
-                        });
-                    });
                 }
             },
             noColors: {
@@ -841,6 +831,9 @@ ${YUNO_PINK}           "I'll protect this server forever... just for you~"${RESE
 
         // Setup auto-reconnection handlers
         this._setupReconnectionHandlers();
+
+        // Start event loop lag monitor (100ms threshold)
+        _startEventLoopMonitor(this.prompt);
 
         this.prompt.info("Bot launched.");
     }

--- a/start.sh
+++ b/start.sh
@@ -6,8 +6,24 @@
 # Enable Node.js 24 experimental features
 export NODE_ENV=production
 
+# Resolve the bot's directory from the script's location so that the
+# Node.js Permission Model paths are correct regardless of where start.sh
+# is called from (e.g. a tmux session launched from a different cwd).
+BOT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 # Node.js 24 native SQLite support
 NODE_OPTIONS="--experimental-sqlite"
+
+# === PERMISSION MODEL ===
+# Restricts the process to its own directory only.
+# --allow-fs-read=$BOT_DIR   : read config, db, node_modules, src
+# --allow-fs-write=$BOT_DIR  : write database, BANS-*.txt, logs
+# --allow-child-process      : db-integrity-check.js, git (auto-update)
+# --allow-addons             : bufferutil, utf-8-validate, zlib-sync (Discord.js native addons)
+#
+# NOTE: If your database path in config.json is an absolute path outside the
+# bot directory, add an extra --allow-fs-read=/path/to/db --allow-fs-write=/path/to/db
+NODE_OPTIONS="$NODE_OPTIONS --permission --allow-fs-read=$BOT_DIR --allow-fs-write=$BOT_DIR --allow-child-process --allow-addons"
 
 # === MEMORY CONFIGURATION ===
 # Detect if running on a low-memory system (Pi, embedded, <4GB RAM)


### PR DESCRIPTION
## Summary

Closes out the remaining OWASP Node.js Security Cheat Sheet items.

- **`_eval()` + `--debug-script` removed** — the `eval()` method and the `--debug-script` CLI arg that read-and-eval'd an arbitrary file are both gone from `Yuno.js`. The `eval.js` command was already removed from `commands/`; this eliminates the last eval surface in the codebase.
- **ReDoS patterns fixed in `Util.js`** — two greedy `.*` patterns inside non-anchored groups (`/\[.*\]/` and `/\(Source: .*\)/`) on anime/manga API descriptions could cause O(n²) backtracking on malformed input. Replaced with negated character classes (`[^\]]*`, `[^)]*`) for guaranteed linear-time matching.
- **Event loop lag monitor** — a `setInterval` (100ms threshold, `.unref()`'d) in `Yuno.js` logs a warning whenever the event loop is blocked. Catches future synchronous I/O regressions that would degrade bot responsiveness.
- **Node.js Permission Model** (`npm start`) — production start script now passes `--permission --allow-fs-read=. --allow-fs-write=. --allow-child-process`, restricting filesystem access to the bot's working directory. Dev script intentionally left unrestricted for hot-reload.
- **ESLint + `eslint-plugin-security`** — `eslint.config.mjs` added with `no-eval`, `no-implied-eval`, `no-new-func`, `no-proto`, `no-extend-native` rules. Run `npm run lint` (after `npm install`) to catch dangerous patterns across all 127 source files automatically.

## Test plan
- [ ] `npm run lint` (after `npm install`) — should complete with 0 errors on `src/`
- [ ] `npm start` — confirm bot starts normally under `--permission` flags
- [ ] Verify `--debug-script` CLI arg is no longer listed in `--help` output
- [ ] Confirm event loop monitor logs a warning if a blocking operation is introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)