### PR TITLE
Security: add Node.js Permission Model to start.sh

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -6,8 +6,24 @@
 # Enable Node.js 24 experimental features
 export NODE_ENV=production
 
+# Resolve the bot's directory from the script's location so that the
+# Node.js Permission Model paths are correct regardless of where start.sh
+# is called from (e.g. a tmux session launched from a different cwd).
+BOT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
 # Node.js 24 native SQLite support
 NODE_OPTIONS="--experimental-sqlite"
+
+# === PERMISSION MODEL ===
+# Restricts the process to its own directory only.
+# --allow-fs-read=$BOT_DIR   : read config, db, node_modules, src
+# --allow-fs-write=$BOT_DIR  : write database, BANS-*.txt, logs
+# --allow-child-process      : db-integrity-check.js, git (auto-update)
+# --allow-addons             : bufferutil, utf-8-validate, zlib-sync (Discord.js native addons)
+#
+# NOTE: If your database path in config.json is an absolute path outside the
+# bot directory, add an extra --allow-fs-read=/path/to/db --allow-fs-write=/path/to/db
+NODE_OPTIONS="$NODE_OPTIONS --permission --allow-fs-read=$BOT_DIR --allow-fs-write=$BOT_DIR --allow-child-process --allow-addons"
 
 # === MEMORY CONFIGURATION ===
 # Detect if running on a low-memory system (Pi, embedded, <4GB RAM)


### PR DESCRIPTION
## Summary

`start.sh` bypasses the `--permission` flags added to `package.json` because it constructs `NODE_OPTIONS` and calls `node` directly. This PR brings it in line.

- **`BOT_DIR` resolution** — added `BOT_DIR="$(cd "$(dirname "$0")" && pwd)"` so the permission paths are always absolute, regardless of what directory the script is launched from (tmux, cron, etc.).
- **Permission flags added to `NODE_OPTIONS`**:
  - `--permission` — enables the Permission Model
  - `--allow-fs-read=$BOT_DIR` — read access to config, database, `node_modules`, `src`
  - `--allow-fs-write=$BOT_DIR` — write access to database, `BANS-*.txt`, logs
  - `--allow-child-process` — needed for the `db-integrity-check.js` subprocess and `git` calls in the auto-updater
  - `--allow-addons` — required for `bufferutil`, `utf-8-validate`, and `zlib-sync` (all three are installed as optional native addons for Discord.js)
- **`yuno-tmux.sh` unchanged** — it calls `./start.sh`, so it inherits these flags automatically.

## Note for operators
If `database` in `config.json` is set to an absolute path outside the bot directory (e.g. `/var/db/yuno.db`), add the corresponding `--allow-fs-read` and `--allow-fs-write` entries to the `NODE_OPTIONS` line in `start.sh`.

## Test plan
- [ ] `./start.sh` — bot starts normally; check logs confirm no Permission Model errors
- [ ] `./scripts/yuno-tmux.sh start` — tmux session starts cleanly
- [ ] Verify `db-integrity-check.js` subprocess still runs at startup (`[DB-INTEGRITY]` lines in logs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)