### PR TITLE
security: randomness/jitter hardening across rate limiters and caches

### DIFF
--- a/src/lib/commandManager.js
+++ b/src/lib/commandManager.js
@@ -105,10 +105,14 @@ function _checkRateLimit(userId, isMaster) {
 
 // Amortised map cleanup: evict entries whose backoff has expired and bucket is
 // essentially full (they would be re-initialised identically on next touch).
+// Threshold is randomized 300–699 so an attacker cannot infer map size from
+// the periodic cleanup pause.
 let _rlTrimCounter = 0;
+let _rlTrimThreshold = 300 + Math.floor(Math.random() * 400);
 function _maybeCleanRateLimitMap() {
-    if (++_rlTrimCounter < 500) return;
+    if (++_rlTrimCounter < _rlTrimThreshold) return;
     _rlTrimCounter = 0;
+    _rlTrimThreshold = 300 + Math.floor(Math.random() * 400); // re-randomize each cycle
     const now = Date.now();
     for (const [uid, entry] of _rlBuckets) {
         if (entry.backoffUntil < now && entry.violations === 0) _rlBuckets.delete(uid);

--- a/src/lib/lruCache.js
+++ b/src/lib/lruCache.js
@@ -43,8 +43,8 @@ LRUCache.prototype.get = function(key) {
         return undefined;
     }
 
-    // Check if expired
-    if (this.ttl > 0 && Date.now() - entry.timestamp > this.ttl) {
+    // Check if expired using per-entry jittered TTL (set at insertion time)
+    if (this.ttl > 0 && Date.now() - entry.timestamp > entry.effectiveTtl) {
         this.cache.delete(key);
         return undefined;
     }
@@ -73,9 +73,12 @@ LRUCache.prototype.set = function(key, value) {
         this.cache.delete(oldestKey);
     }
 
+    // Per-entry TTL jitter ±10% so cache expiry timing is not exactly predictable
+    const effectiveTtl = this.ttl > 0 ? this.ttl * (0.9 + Math.random() * 0.2) : 0;
     this.cache.set(key, {
         value: value,
-        timestamp: Date.now()
+        timestamp: Date.now(),
+        effectiveTtl
     });
 };
 
@@ -91,8 +94,8 @@ LRUCache.prototype.has = function(key) {
         return false;
     }
 
-    // Check if expired
-    if (this.ttl > 0 && Date.now() - entry.timestamp > this.ttl) {
+    // Check if expired using per-entry jittered TTL
+    if (this.ttl > 0 && Date.now() - entry.timestamp > entry.effectiveTtl) {
         this.cache.delete(key);
         return false;
     }

--- a/src/lib/rateLimitHelper.js
+++ b/src/lib/rateLimitHelper.js
@@ -57,13 +57,16 @@ function getRateLimitDelay(client) {
         // Exponential backoff if we're hitting limits frequently
         if (rateLimitState.consecutiveHits > 0) {
             const timeSinceLastHit = now - rateLimitState.lastHit;
-            // Reset consecutive hits if it's been more than 30 seconds
-            if (timeSinceLastHit > 30000) {
+            // Reset window is jittered ±17% around 30s so probe timing is not predictable
+            const resetWindow = 25000 + Math.floor(Math.random() * 10000);
+            if (timeSinceLastHit > resetWindow) {
                 rateLimitState.consecutiveHits = 0;
                 return 10;
             }
-            // Exponential backoff: 50ms * 2^hits, max 5 seconds
-            return Math.min(50 * Math.pow(2, rateLimitState.consecutiveHits), 5000);
+            // Exponential backoff with ±25% jitter so penalty duration is non-deterministic
+            const rawBackoff = 50 * Math.pow(2, rateLimitState.consecutiveHits);
+            const backoffJitter = 0.75 + Math.random() * 0.5;
+            return Math.min(rawBackoff * backoffJitter, 5000);
         }
 
         // No rate limit issues - minimal delay

--- a/src/modules/activity-logger.js
+++ b/src/modules/activity-logger.js
@@ -182,7 +182,9 @@ const STATUS_EMOJIS = {
  */
 async function getGuildSettings(guildId) {
     const cached = settingsCache.get(guildId);
-    if (cached && Date.now() - cached.time < SETTINGS_CACHE_TTL) {
+    // TTL jitter ±30% so an attacker cannot time cache-miss latency spikes precisely
+    const effectiveTtl = SETTINGS_CACHE_TTL * (0.7 + Math.random() * 0.6);
+    if (cached && Date.now() - cached.time < effectiveTtl) {
         return cached.settings;
     }
 
@@ -448,9 +450,11 @@ async function flushAllLogs() {
         const settings = await getGuildSettings(guildId);
         const flushIntervalMs = (settings.flushInterval || DEFAULT_FLUSH_INTERVAL) * 1000;
 
-        // Check if enough time has passed since last flush for this guild
+        // Check if enough time has passed since last flush for this guild.
+        // ±25% jitter on the interval prevents an observer from timing the exact flush cadence.
+        const jitteredIntervalMs = flushIntervalMs * (0.75 + Math.random() * 0.5);
         const lastFlush = lastFlushTime.get(guildId) || 0;
-        if (now - lastFlush < flushIntervalMs) {
+        if (now - lastFlush < jitteredIntervalMs) {
             continue; // Not time to flush this guild yet
         }
 

--- a/src/modules/alt-detector.js
+++ b/src/modules/alt-detector.js
@@ -107,6 +107,10 @@ let discordConnected = async function(Yuno) {
                 const action = config[actionField] || "none";
                 if (action === "none") return;
 
+                // Random delay (200–700ms) before acting so join→action latency does
+                // not reveal whether detection fired or what the outcome is.
+                await new Promise(resolve => setTimeout(resolve, 200 + Math.floor(Math.random() * 500)));
+
                 // Always log to the log channel if one is set (regardless of action type)
                 if (config.logChannelId) {
                     await postToLogChannel(config.logChannelId, member, category, score, member.guild);

--- a/src/modules/dm-handler.js
+++ b/src/modules/dm-handler.js
@@ -44,7 +44,9 @@ const rateLimitState = new Map();
 
 /**
  * Get or create per-user rate limit state.
- * baseLimit is randomized per session (re-randomizes on TTL expiry).
+ * baseLimit, spamThreshold, and leniencyMs are all randomized per session
+ * (re-randomize on TTL expiry) so an attacker probing one session cannot
+ * deduce the thresholds for the next.
  */
 function getOrCreateState(userId) {
     let state = userRateCache.get(userId);
@@ -54,7 +56,9 @@ function getOrCreateState(userId) {
             baseLimit: 6 + Math.floor(Math.random() * 5),  // jittered: 6-10
             droppedCount: 0,                                // messages dropped this session
             lastHumanReply: 0,                              // timestamp of last human reply
-            spamActionTaken: false
+            spamActionTaken: false,
+            spamThreshold: 4 + Math.floor(Math.random() * 3),              // 4-6 (was fixed 5)
+            leniencyMs: HUMAN_REPLY_LENIENCY_MS * (0.75 + Math.random() * 0.5) // ±25%
         };
     }
     return state;
@@ -71,11 +75,12 @@ function checkAndRecord(userId) {
     // Prune messages outside the sliding window
     state.messages = state.messages.filter(t => now - t < RATE_WINDOW_MS);
 
-    // Adaptive effective limit: tightens by 1 for each previously dropped message
-    let effectiveLimit = Math.max(2, state.baseLimit - state.droppedCount);
+    // Adaptive effective limit: tightens by 1 for each previously dropped message.
+    // ±1 micro-jitter makes the exact threshold unpredictable per-check.
+    let effectiveLimit = Math.max(2, state.baseLimit - state.droppedCount + Math.floor(Math.random() * 3) - 1);
 
-    // Leniency boost if a human has replied recently
-    if (now - state.lastHumanReply < HUMAN_REPLY_LENIENCY_MS) {
+    // Leniency boost if a human has replied recently (window is per-session randomized)
+    if (now - state.lastHumanReply < (state.leniencyMs || HUMAN_REPLY_LENIENCY_MS)) {
         effectiveLimit += 5;
     }
 
@@ -97,8 +102,10 @@ function checkAndRecord(userId) {
 function isSpam(userId) {
     const state = userRateCache.get(userId);
     if (!state || state.spamActionTaken) return false;
-    const recentReply = (Date.now() - state.lastHumanReply) < HUMAN_REPLY_LENIENCY_MS;
-    return state.droppedCount >= SPAM_DROP_THRESHOLD && !recentReply;
+    const leniencyMs = state.leniencyMs || HUMAN_REPLY_LENIENCY_MS;
+    const threshold = state.spamThreshold || SPAM_DROP_THRESHOLD;
+    const recentReply = (Date.now() - state.lastHumanReply) < leniencyMs;
+    return state.droppedCount >= threshold && !recentReply;
 }
 
 /**
@@ -379,7 +386,9 @@ module.exports.notifyHumanReply = function(userId) {
             baseLimit: 6 + Math.floor(Math.random() * 5),
             droppedCount: 0,
             lastHumanReply: 0,
-            spamActionTaken: false
+            spamActionTaken: false,
+            spamThreshold: 4 + Math.floor(Math.random() * 3),
+            leniencyMs: HUMAN_REPLY_LENIENCY_MS * (0.75 + Math.random() * 0.5)
         };
     }
     state.lastHumanReply = Date.now();


### PR DESCRIPTION
## Summary

Implements the fuzzing/randomness hardening analysis findings — replaces fixed constants with per-session or per-call jitter throughout the bot's security-sensitive subsystems so an attacker cannot predict or probe exact thresholds.

**commandManager.js**
- Cleanup threshold randomized to 300–699 on each cycle (was fixed 500), preventing inference of rate-limit map size from timing of the periodic cleanup pause

**rateLimitHelper.js**
- Reset window jittered 25–35s (was exactly 30s) — prevents probing every 29s to stay under limit
- Exponential backoff multiplied by ±25% jitter per call so penalty duration is non-deterministic

**lruCache.js**
- Per-entry effective TTL jittered ±10% at insertion time — cache expiry timing is no longer exact or predictable across entries

**dm-handler.js**
- `spamThreshold` (4–6, was fixed 5) and `leniencyMs` (±25% around 10 min) are now randomized per user session and re-randomized when the session TTL expires
- ±1 micro-jitter applied to `effectiveLimit` on each rate-limit check

**activity-logger.js**
- Flush interval jittered ±25% per guild per check cycle
- Settings cache TTL jittered ±30% per lookup — prevents timing cache-miss latency spikes

**alt-detector.js**
- 200–700ms random delay inserted before kick/ban/role action so the latency between a member join event and an action no longer reveals whether or not detection fired

## Test plan
- [ ] Confirm bot starts and commands respond normally
- [ ] Verify DM rate limiting still works (messages still get dropped after burst)
- [ ] Verify alt-detector still kicks/bans on detection (action just has a short extra delay)
- [ ] Verify activity-logger still flushes logs (check log channels after voice/nickname events)

🤖 Generated with [Claude Code](https://claude.com/claude-code)