### PR TITLE
fix: remove accidental git conflict marker from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "generate-doc": "jsdoc .\\src -r -p -d docs -t node_modules/docdash",
     "generate-doc-notheme": "jsdoc .\\src -r -p -d docs",
     "check-db": "node --experimental-sqlite src/scripts/db-integrity-check.js",
-<<<<<<< HEAD
     "check-db:fix": "node --experimental-sqlite src/scripts/db-integrity-check.js --fix",
     "migrate-v2": "node --experimental-sqlite src/scripts/migrate-encryption-v2.js",
     "migrate-v2:dry": "node --experimental-sqlite src/scripts/migrate-encryption-v2.js --dry-run"


### PR DESCRIPTION
## Summary

- `package.json` line 17 contained a bare `<<<<<<< HEAD` conflict marker that was accidentally committed during the previous merge conflict resolution
- This caused a JSON parse error at startup, preventing the bot from launching

**Reproduces as:** `SyntaxError: package.json: Expected double-quoted property name in JSON at position 787 (line 17 column 1)`

## Root cause

When the merge conflict in `package.json` was resolved on branch `fix/migrate-encryption-v2`, only the HEAD side of the diff was kept (correct) but the `<<<<<<< HEAD` marker line itself was left in the file before committing.

## Fix

One-line deletion of the stray conflict marker. No functional change to scripts or dependencies.

## Test plan
- [ ] `node -e "JSON.parse(require('fs').readFileSync('package.json','utf8'))"` succeeds
- [ ] `./start.sh` no longer throws a JSON parse error

🤖 Generated with [Claude Code](https://claude.com/claude-code)