### PR TITLE
security: zero-trust hardening, privilege fixes, and avatar-ban command

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
     "generate-doc": "jsdoc .\\src -r -p -d docs -t node_modules/docdash",
     "generate-doc-notheme": "jsdoc .\\src -r -p -d docs",
     "check-db": "node --experimental-sqlite src/scripts/db-integrity-check.js",
-<<<<<<< HEAD
     "check-db:fix": "node --experimental-sqlite src/scripts/db-integrity-check.js --fix",
     "migrate-v2": "node --experimental-sqlite src/scripts/migrate-encryption-v2.js",
     "migrate-v2:dry": "node --experimental-sqlite src/scripts/migrate-encryption-v2.js --dry-run"

--- a/src/commands/add-masteruser.js
+++ b/src/commands/add-masteruser.js
@@ -40,10 +40,14 @@ module.exports.run = async function(yuno, author, args, msg) {
     if (args.length === 0)
         return msg.channel.send(":negative_squared_cross_mark: Not enough arguments.");
 
-    const user = msg.mentions.members.first()?.id ?? args[0];
+    const rawId = msg.mentions.members.first()?.id ?? args[0];
+
+    // Validate: must be a Discord snowflake (17-19 digit numeric string)
+    if (!/^\d{17,19}$/.test(rawId))
+        return msg.channel.send(":negative_squared_cross_mark: Invalid user ID. Please mention a user or provide a valid Discord user ID.");
 
     const mu = yuno.config.get("commands.master-users");
-    mu.push(user);
+    mu.push(rawId);
     yuno.config.set("commands.master-users", mu);
 
     yuno.config.save();

--- a/src/commands/avatar-ban.js
+++ b/src/commands/avatar-ban.js
@@ -1,0 +1,239 @@
+/*
+    Yuno Gasai. A Discord.JS based bot, with multiple features.
+    Copyright (C) 2018 Maeeen <maeeennn@gmail.com>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU Affero General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with this program.  If not, see https://www.gnu.org/licenses/.
+*/
+
+"use strict";
+
+
+const crypto = require("crypto");
+const { EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require("discord.js");
+const { setupRateLimitListener, waitForRateLimit } = require("../lib/rateLimitHelper");
+
+const AVATAR_SIZE      = 256;
+const FETCH_TIMEOUT_MS = 15_000;
+const BATCH_SIZE       = 15;   // parallel avatar fetches per round
+const COLLECTOR_TTL_MS = 120_000;
+
+/**
+ * Download url and return its SHA-256 hex digest.
+ * Uses global fetch (Node 18+). Times out after FETCH_TIMEOUT_MS.
+ */
+async function fetchAvatarHash(url) {
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+    try {
+        const res = await fetch(url, { signal: controller.signal });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        const buf = await res.arrayBuffer();
+        return crypto.createHash("sha256").update(Buffer.from(buf)).digest("hex");
+    } finally {
+        clearTimeout(timer);
+    }
+}
+
+module.exports.run = async function(yuno, author, args, msg) {
+    // Server-owner-only gate (bot master users also bypass)
+    if (msg.guild.ownerId !== msg.author.id && !yuno.commandMan._isUserMaster(msg.author.id)) {
+        return msg.channel.send(":lock: This command is restricted to the server owner.");
+    }
+
+    const statusMsg = await msg.channel.send(":hourglass: Fetching all guild members…");
+    const cleanupRL = setupRateLimitListener(yuno.dC);
+
+    try {
+        await msg.guild.members.fetch(); // populate cache
+        const allMembers = Array.from(msg.guild.members.cache.values()).filter(m => !m.user.bot);
+        const total = allMembers.length;
+
+        await statusMsg.edit(`:hourglass: Scanning ${total} member avatars — this may take a while on large servers…`);
+
+        // --- Categorise members ---
+        // "default" = no custom avatar at all (neither global nor server-specific)
+        const defaultMembers = [];
+        // hash → GuildMember[] for members with custom avatars
+        const hashMap = new Map();
+        let fetchErrors = 0;
+        let processed   = 0;
+
+        for (let i = 0; i < allMembers.length; i += BATCH_SIZE) {
+            const batch = allMembers.slice(i, i + BATCH_SIZE);
+
+            // allSettled so one failing fetch doesn't abort the whole batch
+            await Promise.allSettled(batch.map(async (member) => {
+                if (!member.user.avatar && !member.avatar) {
+                    // No custom avatar anywhere — completely default
+                    defaultMembers.push(member);
+                } else {
+                    // displayAvatarURL picks server avatar if set, else global.
+                    // forceStatic=true ensures GIFs are hashed as a fixed frame.
+                    const url = member.displayAvatarURL({ extension: "png", size: AVATAR_SIZE, forceStatic: true });
+                    try {
+                        const hash = await fetchAvatarHash(url);
+                        if (!hashMap.has(hash)) hashMap.set(hash, []);
+                        hashMap.get(hash).push(member);
+                    } catch {
+                        fetchErrors++;
+                    }
+                }
+                processed++;
+            }));
+
+            // Progress update every ~150 members
+            if (i > 0 && i % 150 < BATCH_SIZE) {
+                await statusMsg.edit(`:hourglass: Scanned ${processed}/${total} avatars…`).catch(() => {});
+            }
+
+            await waitForRateLimit(yuno.dC);
+        }
+
+        // Duplicate groups: 2+ members sharing the exact same image bytes (same SHA-256)
+        const dupeGroups = Array.from(hashMap.values()).filter(g => g.length > 1);
+        const dupeCount  = dupeGroups.reduce((n, g) => n + g.length, 0);
+
+        // --- Build result embed ---
+        const embed = new EmbedBuilder()
+            .setColor(0xff6600)
+            .setTitle(":camera: Avatar Scan Complete")
+            .addFields(
+                { name: "Members Scanned",   value: String(total),                 inline: true },
+                { name: "Default Avatar",    value: String(defaultMembers.length),  inline: true },
+                { name: "Duplicate Groups",  value: String(dupeGroups.length),     inline: true },
+                { name: "In Dupe Groups",    value: String(dupeCount),             inline: true },
+                { name: "Fetch Errors",      value: String(fetchErrors),           inline: true },
+            )
+            .setTimestamp();
+
+        if (dupeGroups.length > 0) {
+            const lines = dupeGroups.slice(0, 8)
+                .map((g, i) => `**Group ${i + 1}** (${g.length} members): ${g.map(m => m.user.tag).join(", ")}`)
+                .join("\n");
+            const overflow = dupeGroups.length > 8 ? `\n*…and ${dupeGroups.length - 8} more group(s)*` : "";
+            embed.addFields({ name: "Duplicate Groups (preview)", value: (lines + overflow).slice(0, 1024) });
+        }
+
+        if (dupeCount === 0 && defaultMembers.length === 0) {
+            embed.setColor(0x43cc24).setDescription(":white_check_mark: No duplicate or default avatars found.");
+            return await statusMsg.edit({ content: null, embeds: [embed] });
+        }
+
+        // --- Interactive confirmation buttons ---
+        // Use msg.id (unique per invocation) so multiple runs don't collide.
+        const mkId = (action) => `avban-${action}-${msg.id}`;
+
+        const row = new ActionRowBuilder().addComponents(
+            new ButtonBuilder()
+                .setCustomId(mkId("dupes"))
+                .setLabel(`Ban duplicate avatars (${dupeCount})`)
+                .setStyle(ButtonStyle.Danger)
+                .setDisabled(dupeCount === 0),
+            new ButtonBuilder()
+                .setCustomId(mkId("default"))
+                .setLabel(`Ban default avatars (${defaultMembers.length})`)
+                .setStyle(ButtonStyle.Danger)
+                .setDisabled(defaultMembers.length === 0),
+            new ButtonBuilder()
+                .setCustomId(mkId("both"))
+                .setLabel(`Ban both (${dupeCount + defaultMembers.length})`)
+                .setStyle(ButtonStyle.Danger)
+                .setDisabled(dupeCount === 0 || defaultMembers.length === 0),
+            new ButtonBuilder()
+                .setCustomId(mkId("cancel"))
+                .setLabel("Cancel")
+                .setStyle(ButtonStyle.Secondary),
+        );
+
+        await statusMsg.edit({ content: null, embeds: [embed], components: [row] });
+
+        const collector = msg.channel.createMessageComponentCollector({
+            filter: (i) => i.user.id === msg.author.id && i.customId.endsWith(`-${msg.id}`),
+            time: COLLECTOR_TTL_MS,
+            max: 1,
+        });
+
+        collector.on("collect", async (interaction) => {
+            // customId format: "avban-<action>-<msgId>"
+            const action = interaction.customId.split("-")[1]; // dupes | default | both | cancel
+
+            if (action === "cancel") {
+                await interaction.update({ components: [] });
+                return;
+            }
+
+            await interaction.update({ content: ":hourglass: Applying bans…", embeds: [embed], components: [] });
+
+            const toBan = [
+                ...(action === "dupes"   || action === "both" ? dupeGroups.flat() : []),
+                ...(action === "default" || action === "both" ? defaultMembers    : []),
+            ];
+
+            let succeeded = 0, skipped = 0, failed = 0;
+            const reason = `Avatar-ban (${action}) — requested by ${msg.author.tag} (${msg.author.id})`;
+
+            for (const member of toBan) {
+                // Never ban master users or the server owner
+                if (yuno.commandMan._isUserMaster(member.id) || member.id === msg.guild.ownerId) {
+                    skipped++;
+                    continue;
+                }
+                try {
+                    await member.ban({ deleteMessageSeconds: 0, reason });
+                    succeeded++;
+                } catch {
+                    failed++;
+                }
+                await waitForRateLimit(yuno.dC);
+            }
+
+            const resultEmbed = new EmbedBuilder()
+                .setColor(failed === 0 ? 0x43cc24 : 0xffa500)
+                .setTitle(":white_check_mark: Ban Operation Complete")
+                .addFields(
+                    { name: "Banned",        value: String(succeeded), inline: true },
+                    { name: "Skipped",       value: String(skipped),   inline: true },
+                    { name: "Failed",        value: String(failed),    inline: true },
+                )
+                .setTimestamp();
+
+            await statusMsg.edit({ content: null, embeds: [embed, resultEmbed], components: [] });
+        });
+
+        collector.on("end", (collected) => {
+            if (collected.size === 0) {
+                // Timed out — remove the buttons
+                statusMsg.edit({ components: [] }).catch(() => {});
+            }
+        });
+
+    } catch (e) {
+        await statusMsg.edit(`:negative_squared_cross_mark: Scan failed: ${e.message}`).catch(() => {});
+    } finally {
+        cleanupRL();
+    }
+};
+
+module.exports.about = {
+    command: "avatar-ban",
+    description: "Scan all member avatars via SHA-256 checksum. Detects duplicate avatars (possible shared/alt accounts) and members with no custom avatar. Presents an interactive confirmation before banning. Server owner only.",
+    examples: ["avatar-ban"],
+    discord: true,
+    terminal: false,
+    list: true,
+    listTerminal: false,
+    requiredPermissions: ["BanMembers"],
+    aliases: ["avban", "pfpban"],
+    dangerous: true,
+};

--- a/src/commands/avatar-ban.js
+++ b/src/commands/avatar-ban.js
@@ -233,7 +233,7 @@ module.exports.about = {
     terminal: false,
     list: true,
     listTerminal: false,
-    requiredPermissions: ["BanMembers"],
+    requiredPermissions: ["ManageGuild", "BanMembers"],
     aliases: ["avban", "pfpban"],
     dangerous: true,
 };

--- a/src/commands/config.js
+++ b/src/commands/config.js
@@ -30,15 +30,23 @@ const say = (yuno, isTerminal, msg, tosay) =>
 // the config store. JSON.parse in modern Node.js does not actually pollute
 // Object.prototype, but downstream code or future changes might; this provides
 // defense-in-depth for a state-actor threat model.
+// Deep-walk required: a nested {"a": {"__proto__": ...}} bypasses shallow checks.
 const POISONING_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+
+function _hasPoisoningKey(obj, depth = 0) {
+    if (depth > 20 || obj === null || typeof obj !== "object") return false;
+    for (const key of Object.keys(obj)) {
+        if (POISONING_KEYS.has(key)) return true;
+        if (_hasPoisoningKey(obj[key], depth + 1)) return true;
+    }
+    return false;
+}
 
 const tryParseJSON = (str) => {
     try {
         const parsed = JSON.parse(str);
-        if (parsed !== null && typeof parsed === "object" && !Array.isArray(parsed)) {
-            for (const key of Object.keys(parsed)) {
-                if (POISONING_KEYS.has(key)) return str; // reject, use raw string
-            }
+        if (parsed !== null && typeof parsed === "object" && _hasPoisoningKey(parsed)) {
+            return str; // reject — return raw string so it's stored literally, not executed
         }
         return parsed;
     } catch { return str; }

--- a/src/commands/scan-alts.js
+++ b/src/commands/scan-alts.js
@@ -238,7 +238,7 @@ module.exports.about = {
     "terminal": false,
     "list": true,
     "listTerminal": false,
-    "requiredPermissions": ["BanMembers"],
+    "requiredPermissions": ["ManageGuild", "BanMembers"],
     "aliases": ["scanalts", "altscan"],
     "dangerous": true
 };

--- a/src/commands/scan-alts.js
+++ b/src/commands/scan-alts.js
@@ -39,6 +39,10 @@ const CATEGORY_EMOJI = {
 const CHUNK_SIZE = 50;
 
 module.exports.run = async function(yuno, author, args, msg) {
+    if (msg.guild.ownerId !== msg.author.id && !yuno.commandMan._isUserMaster(msg.author.id)) {
+        return msg.channel.send(":lock: This command is restricted to the server owner.");
+    }
+
     const statusMsg = await msg.channel.send(":hourglass: Fetching all guild members... This may take a while for large servers.");
 
     const cleanupRateLimit = setupRateLimitListener(yuno.dC);
@@ -234,7 +238,7 @@ module.exports.about = {
     "terminal": false,
     "list": true,
     "listTerminal": false,
-    "requiredPermissions": ["ManageGuild", "KickMembers", "BanMembers"],
+    "requiredPermissions": ["BanMembers"],
     "aliases": ["scanalts", "altscan"],
     "dangerous": true
 };

--- a/src/commands/scan-alts.js
+++ b/src/commands/scan-alts.js
@@ -234,7 +234,7 @@ module.exports.about = {
     "terminal": false,
     "list": true,
     "listTerminal": false,
-    "requiredPermissions": ["ManageGuild"],
+    "requiredPermissions": ["ManageGuild", "KickMembers", "BanMembers"],
     "aliases": ["scanalts", "altscan"],
     "dangerous": true
 };


### PR DESCRIPTION
## Summary

- **package.json** — removes accidental `<<<<<<< HEAD` conflict marker that broke startup (same fix as hotfix PR #135)
- **add-masteruser** — validate Discord snowflake format (`^\d{17-19}$`) before pushing to master-users list; Discord path previously accepted any raw string
- **config** — deepen prototype-pollution guard from shallow (top-level keys only) to a full recursive walk (depth-capped at 20); nested payloads like `{"a":{"__proto__":{...}}}` previously bypassed it
- **scan-alts** — restrict to server owner / bot master users only; restore `ManageGuild` + `BanMembers` as required permissions
- **avatar-ban** (new command) — server-owner-only command that:
  - Fetches all non-bot members and SHA-256 hashes each avatar (static 256px PNG, batched 15 concurrent)
  - Separates members with zero custom avatar into a "default avatar" bucket
  - Finds duplicate-avatar groups (2+ members sharing identical image bytes)
  - Presents an interactive embed with **Ban duplicates / Ban default avatars / Ban both / Cancel** buttons (120s timeout)
  - Skips master users and the server owner when banning
  - Aliases: `.avban`, `.pfpban` — `dangerous: true` so non-`BanMembers` users are auto-banned on attempt

## Test plan
- [ ] `./start.sh` launches without JSON parse error
- [ ] `.avatar-ban` as a non-owner returns lock message; as owner shows scan embed
- [ ] `.scan-alts` as a non-owner returns lock message; as owner proceeds
- [ ] `.add-masteruser <non-snowflake>` returns invalid ID message
- [ ] `config set key '{"a":{"__proto__":{"x":1}}}'` stores raw string, does not pollute

🤖 Generated with [Claude Code](https://claude.com/claude-code)